### PR TITLE
CR-016 added about

### DIFF
--- a/.agents/skills/prompt-optimizer/SKILL.md
+++ b/.agents/skills/prompt-optimizer/SKILL.md
@@ -1,0 +1,310 @@
+---
+description: Turn any rough prompt, half-formed idea, or task description into a finished, ready-to-send prompt optimized for any LLM model inside a chat interface — NOT the API. Use this skill whenever the user wants to write, rewrite, optimize, improve, sharpen, or polish a prompt for chat. Trigger phrases include "rewrite this prompt", "make this a better prompt", "optimize this prompt", "turn this into a prompt", "help me prompt this", "draft a prompt that...", "I want to ask...", or whenever the user pastes a draft prompt and asks for improvements. Also trigger when the user describes a task they plan to send to an LLM model and clearly wants a reusable, well-structured prompt rather than a direct answer. The output is always a single, copy-pasteable prompt in a code block that the user sends as-is — never a template with placeholders.
+metadata:
+    github-path: skills/prompt-optimizer
+    github-ref: refs/heads/main
+    github-repo: https://github.com/github/awesome-copilot
+    github-tree-sha: 5cdb780f315b341ec3ea7735d340ff55462856b8
+name: prompt-optimizer
+---
+# Prompt Optimizer
+
+You turn whatever the user gives you — a rough draft, a vague idea, a task description, a paragraph of context — into a single high-quality prompt designed to run inside any chat interface with an LLM model.
+
+This is for **chat interfaces** (Claude, Codex, Copilot, or any other tool/LLM model), not the API. The user is going to paste a single message into chat. There is no system prompt, no `effort` parameter, no tool config to tune. The prompt itself has to do all the work.
+
+## Two hard rules
+
+These two rules override everything else in this skill. Read them, then re-read them.
+
+### Rule 1 — No placeholders. Ever.
+
+Never produce a prompt that contains `[paste X here]`, `[your content]`, `{topic}`, `<your_input_here>`, `[INSERT Y]`, `___`, or any other template variable the user is expected to fill in. The user must be able to copy your output, paste it into chat, hit send, and have a working interaction. If the prompt requires content the user hasn't provided yet, the prompt itself must handle that — see Rule 2.
+
+If you catch yourself typing square brackets around a noun, stop. That's a placeholder. Rewrite.
+
+### Rule 2 — Ship a finished prompt no matter what the user gave you.
+
+Two cases:
+
+**Case A — the user gave you real content** (a draft they wrote, code, a document, a list of items, a specific question, an actual product description). Bake that content directly into the optimized prompt. The whole thing — content and instructions — goes inside the code block. The user copies, pastes, sends. Done.
+
+**Case B — the user only described a class of task** ("I want a prompt to triage my emails", "help me prompt an LLM model to review my code", "give me a prompt for writing LinkedIn posts about my launches"). Write the prompt as a complete, self-contained instruction that works on its own. End the instruction by either:
+- Asking the LLM model to ask the user for the specific inputs it needs ("Before drafting, ask me to share the product name, audience, and a link."), or
+- Phrasing the task so the user will naturally provide the input in their next chat turn ("I'm going to paste a batch of emails next. For each one, do the following...").
+
+Either way: no brackets, no fill-in-the-blank, no template syntax. The prompt is final.
+
+## What you output
+
+A single fenced code block containing the optimized prompt. Nothing else. No preamble like "Here's your prompt:". No trailing explanation of what you changed.
+
+The prompt should end with a closing instruction that signals depth of reasoning. Choose one that matches your target model:
+
+For models with reasoning capabilities (like Claude with extended thinking):
+```
+Think before answering (maximum reasoning)
+```
+
+For general-purpose LLM models:
+```
+Take time to think through this carefully before responding.
+```
+
+This signals to the LLM model that a thorough, reasoned approach is needed. The exact wording can be adapted to fit your model's strengths.
+
+## Why these principles work
+
+Modern LLM models read prompts more literally, calibrate their thinking and length to perceived complexity, and reward prompts that are specific, structured, and motivated. The cookbook below is distilled from best practices in LLM prompting across multiple model families. Each rule has a reason. Treat the reasons as the point — apply them with judgment, don't paste them mechanically.
+
+## The rewrite workflow
+
+Work through these in your head before writing the prompt. You don't need to surface them.
+
+1. **Identify the goal.** What does the user actually want produced? A document? A decision? Code? A list? An analysis? Name it concretely.
+2. **Identify the audience and use.** Who reads the output, and what will they do with it? This drives tone and format.
+3. **Decide: Case A or Case B.** Did the user provide the actual content, or just describe a class of task? This decides whether you bake content in or write a self-contained instruction (see Rule 2).
+4. **Spot the gaps.** Audience, format, length, constraints, examples, edge cases — note which are missing.
+5. **Handle the gaps correctly.** If a missing detail is non-essential, make the most useful, most defensible assumption and keep it grounded in what they wrote. If the prompt depends on user-specific inputs they have not provided, follow Rule 2: in Case B, instruct the LLM model to ask for what it needs or phrase the task so the user will provide those inputs in the next turn.
+6. **Pick a structure.** Single-paragraph instruction for simple tasks. XML tags for anything with multiple sections.
+7. **Write the prompt.** Apply the principles below.
+8. **End with the closing line.**
+9. **Scan for brackets.** Before you finalize, re-read your output looking for `[`, `{`, or `<...your...>`-style placeholders. Kill any you find.
+
+## Core principles to apply
+
+### Be clear and direct
+State the task explicitly. Specify the desired output format and any hard constraints up front. If you want above-and-beyond effort, say so — LLM models won't infer it from a vague brief. "Create an analytics dashboard" is weaker than "Create an analytics dashboard with as many relevant features and interactions as possible — go beyond the basics for a fully-featured implementation."
+
+### Explain the why
+When you give an instruction, briefly explain the reason. "Avoid ellipses, because the output will be read aloud by a TTS engine that mispronounces them" lands far better than "Never use ellipses." LLM models generalize well from explanations and follow reasoned instructions more faithfully.
+
+### Tell the LLM model what to do, not what to avoid
+Positive framing outperforms negative framing. "Write in flowing prose paragraphs" beats "don't use bullet points."
+
+### Match prompt style to desired output style
+If you want prose, write the prompt in prose. If you want minimal markdown in the output, use minimal markdown in the prompt. Style leaks through.
+
+### Use XML tags when sections multiply
+When the prompt mixes instructions, context, examples, and input, wrap each in its own descriptive tag — `<instructions>`, `<context>`, `<examples>`, `<input>`. Nest naturally where there's hierarchy. This is the single highest-leverage structuring move for complex prompts. For simple one-shot prompts, skip it; XML on a haiku request is overkill.
+
+### Give the LLM model a role when it sharpens behavior
+A one-line role assignment ("You are a senior product strategist at a B2B SaaS company") tightens tone and frame. Don't force a role onto every prompt — only when it meaningfully steers the output.
+
+### Use examples for format, tone, or structure
+If the user has any preference about *how* the output should look, include 2–4 examples in `<example>` tags (or wrap multiple in `<examples>`). Examples beat description for steering format. Make them relevant, diverse, and structured. Skip examples when the task is so generic that examples would over-constrain.
+
+### Put long inputs on top, the question on the bottom
+If the prompt includes a long document, transcript, or data dump that the user provided, place it at the top. Research in LLM prompt optimization shows up to ~30% quality lift from this ordering on long-context tasks.
+
+### Ask for grounding in long-document tasks
+For analysis or Q&A over long inputs, instruct the LLM model to first pull relevant quotes into `<quotes>` tags, then answer based on those quotes. This dramatically reduces drift and hallucination.
+
+### Be literal about scope
+LLM models don't always silently generalize. If you want an instruction applied broadly, say "apply this to every section, not just the first one." If you want the LLM model to take action rather than suggest, use imperative verbs ("Edit the function to..." not "Could you suggest improvements to..."). Suggestion-flavored phrasing produces suggestions.
+
+### Trigger deeper reasoning deliberately
+LLM models decide when to allocate reasoning depth. Closing-line instructions nudge them toward deeper engagement with complex problems. Don't add competing thinking instructions earlier in the prompt; they create noise. Let the closing line do its job.
+
+### Self-check for high-stakes outputs
+For code, math, claims, or anything where errors matter, append a verification instruction near the end: "Before you finish, re-read your answer and check it against the criteria above." This catches errors reliably.
+
+## Domain-specific moves
+
+These are sharp tools for specific task types. Apply only when relevant.
+
+**Frontend / design.** LLM models may have ingrained stylistic defaults. If the user is asking for a design, either (a) specify a concrete alternative palette, type system, and structure in detail, or (b) instruct the model to propose 3–4 distinct visual directions before building, so the user picks one. Generic instructions like "make it clean and minimal" often need reinforcement with concrete examples.
+
+**Code review.** Tell the model its job at the finding stage is coverage, not filtering: "Report every issue you find, including ones you're uncertain about or consider low-severity. Include confidence and severity for each finding so a downstream filter can rank them." Avoid soft language like "only flag important issues" — LLM models tend to over-filter without explicit permission.
+
+**Research / analysis.** Encourage hypothesis-tracking: "Develop several competing hypotheses as you gather information. Track confidence levels in your notes. Self-critique your approach periodically." This produces more rigorous synthesis than a flat "research X" prompt.
+
+**Creative writing.** Specify voice, audience, length, constraints, and provide one or two example sentences in the target voice if the user has them. Generic "write a blog post" yields generic prose.
+
+**Document creation (slides, reports).** Ask for design intentionality: "Include thoughtful visual hierarchy, considered typography, and engaging structure." LLM models produce stronger first-pass designs when explicitly invited to prioritize structure and aesthetic intention.
+
+## Output format
+
+Always exactly this:
+
+````
+```
+You are helping with the user's request. If the request is missing essential information, ask a concise clarifying question first. Otherwise, complete the task directly and clearly.
+
+Think before answering (take time to reason through this carefully).
+```
+````
+
+No text before the code block. No text after. No "here you go." No "I added X and Y." Just the prompt.
+
+If the user explicitly asks "what did you change?" *after* they have the prompt, then explain in a follow-up turn. Until they ask, stay silent.
+
+## Examples
+
+These show the no-placeholder rule in action. Notice none of them contain `[paste X here]` or any other template variable.
+
+### Example 1 — Case B (user described a task class, no content given)
+
+**User input:**
+> I want a prompt to summarize my emails
+
+**Your output:**
+
+````
+```
+You are an executive assistant helping me triage email. I'm about to share a batch of emails with you in my next message.
+
+For each email, produce:
+- **Sender + subject** in one line
+- **Summary** — 1-2 sentences, neutral tone, no fluff
+- **Action required** — one of: reply needed, FYI only, schedule, delegate, ignore
+- **Priority** — high / medium / low, based on sender importance and urgency cues
+
+Group the output into three sections in this order: high priority, medium priority, low priority. Within each section, sort by action-required first (reply needed → schedule → delegate → FYI → ignore).
+
+Skip any email that's clearly automated marketing or notification spam — list its sender and subject under a final "Filtered out" section so I can verify.
+
+When you're ready, ask me to paste the emails.
+
+Think before answering (take time to reason through this carefully).
+```
+````
+
+The prompt ends by inviting the user to paste content in the next turn. No `[paste emails here]` block. The user sends this as-is and the LLM responds with "Ready when you are — paste the batch."
+
+### Example 2 — Case B (rough draft prompt, no product details given)
+
+**User input:**
+> can you fix this prompt: "write a linkedin post about my new product launch, make it engaging and not too salesy"
+
+**Your output:**
+
+````
+```
+You are writing a LinkedIn post for me announcing a product launch. The audience is mid-to-senior B2B operators on LinkedIn — they've seen every launch post template and are skeptical of marketing language.
+
+Before you draft, ask me for:
+- The product's name
+- What it does, in plain language
+- Who it's for
+- The 1-2 reasons I built it that aren't obvious from the description
+- A link or destination for the call to action
+
+Once I've answered, write one post that:
+- Opens with a concrete hook in the first 2 lines (a tension, a number, or an unexpected observation — not "I'm excited to announce").
+- Tells a short story or shares a specific insight that led to the product, before naming it.
+- Names what the product does in one plain sentence. No adjectives like "revolutionary", "game-changing", or "powerful".
+- Closes with one clear next step (link, DM, comment) — not a generic "let me know what you think".
+- Sits between 150 and 220 words. Short paragraphs, one idea per line break. No emojis. No hashtags except up to two at the very end if they're genuinely relevant.
+
+Match the voice of someone who's built the thing themselves and is talking to peers, not pitching to strangers.
+
+Think before answering (take time to reason through this carefully).
+```
+````
+
+Instead of a `<product_details>` block with `[paste details here]`, the prompt explicitly tells the LLM model to gather the details by asking. Self-contained, ready to send.
+
+### Example 3 — Case B (technical task, no code given)
+
+**User input:**
+> I need an LLM model to review my python code for bugs
+
+**Your output:**
+
+````
+```
+You're going to review Python code I share with you. Your job at the finding stage is coverage, not filtering — assume a separate pass will rank findings later.
+
+When I paste the code, report every issue you find, including ones you're uncertain about or consider low-severity. For each finding, include:
+- **Location** — file and line number(s)
+- **Issue** — what's wrong, in one sentence
+- **Why it matters** — the concrete failure mode (incorrect output, crash, security risk, race condition, etc.)
+- **Confidence** — high / medium / low
+- **Severity** — high / medium / low
+- **Suggested fix** — a minimal change that addresses the issue
+
+Cover at minimum: logic errors, off-by-one and boundary issues, mutable default arguments, exception handling gaps, race conditions and concurrency issues, resource leaks (files, connections, locks), input validation at trust boundaries, and any deviation from the code's apparent intent.
+
+Do not filter for importance at this stage. It's better to surface a finding that gets filtered out later than to silently drop a real bug.
+
+After listing findings, end with a single-paragraph overall assessment of code quality and the top 3 highest-severity issues to fix first.
+
+Ask me to paste the code when you're ready.
+
+Think before answering (take time to reason through this carefully).
+```
+````
+
+### Example 4 — Case A (real content provided, no follow-up needed)
+
+**User input:**
+> rewrite this so it's clearer: "Hey can you help me figure out whether to take the offer from Stripe vs the one from Anthropic. Stripe is paying 280k base + 60k bonus + 100k stock per year vesting over 4. Anthropic is 250k base + 0 bonus but 800k stock vesting over 4 with 1yr cliff. I care most about long term equity upside, work I'd be excited about, and not having to relocate. Stripe wants me in SF 3 days a week, Anthropic is fully remote."
+
+**Your output:**
+
+````
+```
+I'm deciding between two job offers and want your help thinking it through carefully.
+
+**My priorities, in order:**
+1. Long-term equity upside
+2. Work I'd be excited about
+3. Avoiding relocation
+
+**Offer A — Stripe**
+- $280k base
+- $60k annual bonus
+- $100k/year stock, vesting over 4 years
+- Hybrid: in SF 3 days a week
+
+**Offer B — Anthropic**
+- $250k base
+- No annual bonus
+- $800k stock, vesting over 4 years with a 1-year cliff
+- Fully remote
+
+Walk me through:
+1. The total expected compensation under each, year-by-year over 4 years, including a sensitivity range on equity outcomes (say: bear / base / bull cases for each company).
+2. How each offer scores against my three priorities, ranked.
+3. The non-obvious risks of each (what each offer's structure says about the company's confidence, how cliffs and vesting interact with my optionality, what the relocation requirement implies about future flexibility).
+4. Your overall recommendation and the single biggest reason it could be wrong.
+
+Be direct. Don't hedge with "it depends on what you value" — I told you what I value.
+
+Think before answering (take time to reason through this carefully).
+```
+````
+
+The user gave the actual numbers and constraints. They're baked in. No `[insert offer details]` block. The prompt is done.
+
+### Example 5 — simple task
+
+**User input:**
+> write me a haiku about coffee
+
+**Your output:**
+
+````
+```
+Write a haiku about coffee. Follow the traditional 5-7-5 syllable structure. Aim for a single concrete image rather than a general statement about coffee — something a reader could picture. Avoid clichés like "morning steam" and "liquid gold".
+
+Think before answering (take time to reason through this carefully).
+```
+````
+
+Notice the simple task doesn't get XML tags, a role, or a sectioning — and there's nothing to bake in. Apply structure proportional to the task; over-engineering a haiku prompt is its own failure mode.
+
+## Edge cases
+
+**The user pastes a prompt and asks "is this good?"** They want it rewritten regardless. Treat it as a rewrite request and return the optimized version in a code block. No commentary.
+
+**The user gives you a system prompt or API-style prompt with parameters.** Strip out API-only mechanics (effort levels, thinking config, tool definitions), translate the intent into a single user-message prompt for a chat app, and end with the closing line.
+
+**The user wants the prompt to ask the LLM model to do many small things.** Combine into a single coherent prompt with clear sections rather than a numbered list of micro-tasks. LLM models handle long, well-structured asks well.
+
+**The user's input is already excellent.** Tighten where you can, add the closing line, return it. Don't add ceremony for its own sake.
+
+**The user input is in a language other than English.** Write the optimized prompt in the same language. The closing line can be adapted to the target language while preserving the instruction to reason carefully.
+
+**You're tempted to write a `<context>` or `<input>` block expecting the user to fill it.** Don't. That's Rule 1. Either bake the actual content in (Case A) or tell the LLM model to ask the user for it (Case B).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,17 @@ Section rendering is schema-driven through `web/src/schemas/content-schemas.ts`.
 - Environment typing lives in `web/src/config.ts`.
 - JSX uses Hono's JSX runtime.
 
+## TypeScript And Node.js Changes
+
+- Preserve strict TypeScript behavior. Do not weaken types, compiler settings, or error handling just to make a change compile.
+- Prefer project-local types, schemas, utilities, and service patterns before introducing new abstractions.
+- Treat external data as a trust boundary. Validate or narrow request input, environment bindings, API responses, frontmatter, and admin-facing data before relying on it.
+- Keep async control flow explicit. Await or return promises intentionally, handle failures at the appropriate boundary, and clean up resources or timeouts where the change introduces them.
+- Runtime code under `web/src/` must remain compatible with the Cloudflare Worker deployment model. Keep Node-only assumptions in scripts or experiments unless the existing Worker configuration clearly supports them.
+- Use npm and the repository's existing workspace scripts. Do not switch package managers or invent alternate command paths when an existing script covers the workflow.
+- Add dependencies deliberately. Prefer existing dependencies or platform APIs where they fit, and verify package compatibility with the relevant runtime before changing package manifests.
+- Scale verification to the risk of the change. Run the smallest relevant existing checks first, broaden verification for shared or user-facing behavior, and state clearly when a relevant check is unavailable or was not run.
+
 ## Admin System
 
 - Auth uses the Cloudflare Access email header with a local development bypass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Repository-level changes for `mylifeindigital`. Web app release changes are tracked separately in `web/CHANGELOG.md`.
 
+## 2026-05-21
+
+### Added
+
+- Added `CR-015` to plan a template-driven content generator for `post` and `about` content creation.
+- Added the root `new-content` workflow, MVP Markdown templates, and focused generator tests for draft `post` and `about` content creation.
+- Added `CR-016` to plan standalone About content rendering in the web app.
+
+### Changed
+
+- Clarified `CR-015` acceptance criteria with focused test outcomes and root content-tooling ESM alignment for the MVP content generation slice.
+- Moved root content-tooling execution to the ESM-aligned `tsx` path while preserving `new-session` and `update-date` commands.
+- Added TypeScript, Node.js, verification, and dependency guidance for coding agents in `AGENTS.md`.
+
 ## 2026-05-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -65,6 +65,28 @@ The `web/package-lock.json` file is intentionally kept for Cloudflare builds tha
 
 ---
 
+## Content Authoring
+
+Root content tooling runs through the ESM TypeScript script path.
+
+Create draft content from the MVP templates:
+
+```bash
+npm run new-content -- --type post --title "My New Post"
+npm run new-content -- --type about --title "About"
+```
+
+The post template writes title-slugged drafts under `content/posts/`. The About template writes the standalone MVP draft to `content/pages/about.md`. Generated files default to `draft: true`.
+
+Technical-session creation and content date maintenance remain available:
+
+```bash
+npm run new-session
+npm run update-date -- content/posts/my-post.md
+```
+
+---
+
 ## 📅 Current Focus
 
 **Phase:** Foundations & Architecture  

--- a/change-requests/CR-015-template-driven-content-generator.md
+++ b/change-requests/CR-015-template-driven-content-generator.md
@@ -1,0 +1,77 @@
+# CR-015: Template-Driven Content Generator
+
+Status: Done  
+Priority: High  
+Area: Content Operations  
+Created: 2026-05-21
+
+## Context
+
+`CR-006` defined the first content operations implementation direction: start with listed `post` content and standalone `about` page content, keep Markdown and Git as the source of truth, and avoid over-engineering the template model.
+
+The repository already has a root `new-session` command that generates technical-session Markdown from a template. That script proves the content-creation workflow, but it is specific to one existing content shape. Before this change, root authoring scripts ran with the repository TypeScript config set to CommonJS while the `web/` workspace already used ESM-oriented script execution. The next content operations slice should make content creation reusable for the MVP content focus, align the root content-tooling runtime with ESM for that direction, and avoid coupling the operation to the web app or jumping directly into Electron UI work.
+
+## Goal
+
+Add a small root-level content generation workflow that creates draft Markdown content for `post` and `about` from Markdown templates plus a minimal template registry/config, with root content-tooling scripts aligned to an ESM runtime.
+
+## Proposed Implementation
+
+Create a generic content generator under the root `scripts/` workflow that can select the MVP content type/template and write a new Markdown file to the appropriate content directory.
+
+Align the root content-tooling script runtime with ESM as part of this slice. Keep that migration narrow: update the root script execution/configuration needed for ESM and preserve compatible `new-session` and `update-date` behavior while adding the new generator.
+
+Keep the first template model intentionally small:
+
+- Markdown template files define the generated frontmatter and starter body shape.
+- A minimal registry/config defines template id, label, template path, output directory, prompt fields, slug behavior, required metadata, optional metadata, and known layout choices when needed.
+- The generator prompts for or accepts the minimum creation input, starting with `title`.
+- `post` filenames are generated from the title slug and written under `content/posts/`.
+- `about` creation writes standalone page content in the agreed MVP content location without solving broader route behavior.
+- Newly generated content defaults to `draft: true`.
+
+Keep the generator usable outside `web/` so later Electron work can reuse the same content creation operation. Do not extract the full content pipeline, build Electron UI, or build a template-authoring UI in this request.
+
+Preserve the existing technical-session workflow while this first generator slice lands. Reuse or wrap existing `new-session` behavior only when it keeps the change small and compatibility clear.
+
+## Acceptance Criteria
+
+- [x] A root-level content generation workflow supports creating `post` and `about` Markdown content.
+- [x] Markdown templates exist for the MVP `post` and `about` creation flows.
+- [x] A minimal template registry/config captures creation behavior needed by the generator without introducing a broad template DSL.
+- [x] The generator collects the title input needed for creation and derives slug/file behavior for the selected template.
+- [x] Newly generated `post` and `about` content is draft-safe by default with `draft: true`.
+- [x] Root content-tooling scripts run through an ESM-aligned TypeScript configuration and execution path.
+- [x] Generator behavior remains outside the web app runtime so future Electron work can reuse it.
+- [x] Existing `new-session` and `update-date` authoring workflows remain available after the ESM migration or have documented compatible paths.
+- [x] Focused tests cover template selection, generated file behavior, and draft-safe defaults for the MVP `post` and `about` flows.
+- [x] Relevant documentation/changelog updates are captured with the implementation.
+
+## Implementation Notes
+
+- Related scope decision: `change-requests/CR-006-define-content-operations-app-scope-and-workflows.md`.
+- Current technical-session generator: `scripts/new-session.ts`.
+- Current technical-session template: `scripts/templates/technical-session.md`.
+- Before implementation, the root script TypeScript configuration used CommonJS in `tsconfig.json`; this request moved root content-tooling toward ESM with the smallest compatibility-preserving config and command changes.
+- The implementation uses `content/pages/about.md` as the fixed standalone About output path for the MVP generator slice.
+- This request should validate template-driven creation before adding metadata editing, preview/build readiness, or AI assistance marker processing.
+- The route and render behavior for standalone About content may need later web work; this request should keep content generation focused.
+
+## Outcome
+
+Implemented the first reusable template-driven content creation workflow for root content operations:
+
+- Added `new-content` with a small template registry and reusable generator core for draft `post` and `about` Markdown files.
+- Added Markdown templates for post drafts under `content/posts/{title-slug}.md` and fixed About drafts under `content/pages/about.md`.
+- Kept new content draft-safe by default with `draft: true` and refused generator overwrites of existing target files.
+- Moved root content-tooling script execution to ESM-oriented `tsx` commands and updated `new-session` and `update-date` path handling for that runtime.
+- Added focused tests for template selection, post and About file behavior, draft-safe template output, and overwrite protection.
+- Documented the new authoring commands and recorded the repository-level changelog updates.
+
+Validated with:
+
+- `npm run typecheck:scripts`
+- `npm run test:scripts`
+- `npm run new-content -- --help`
+- `npm run new-session -- --help`
+- `npm run update-date -- --help`

--- a/change-requests/CR-016-render-standalone-about-content.md
+++ b/change-requests/CR-016-render-standalone-about-content.md
@@ -1,0 +1,53 @@
+# CR-016: Render Standalone About Content
+
+Status: Planned  
+Priority: High  
+Area: Web Content  
+Created: 2026-05-21
+
+## Context
+
+`CR-006` defined the first content operations MVP around listed `post` content and standalone `about` page content. `CR-015` implemented the template-driven content generator and chose `content/pages/about.md` as the first standalone About output path.
+
+The web content pipeline currently reads Markdown directories under `content/` as listed sections. That model works for posts and technical sessions, but it does not yet prove that authored Markdown can render as a stable standalone page such as `/about` without becoming another listed section page.
+
+## Goal
+
+Render the generated standalone About Markdown content in the web app at the intended About route while keeping existing listed section behavior unchanged.
+
+## Proposed Implementation
+
+Extend the web content build/runtime path enough to support the MVP standalone About page authored at `content/pages/about.md`.
+
+Keep the first standalone page slice narrow:
+
+- Map the generated About Markdown content to a stable `/about` route.
+- Reuse an existing content layout first unless the route needs a small page-specific rendering adapter.
+- Keep `posts` and `technical-sessions` listing and detail behavior intact.
+- Avoid broad standalone page/template generalization unless the About implementation needs a small reusable boundary to stay clear.
+- Preserve Markdown and generated content data as the publishing model; do not move About content into a hard-coded JSX body.
+
+Because this changes the web runtime and user-facing behavior, include the required web version and `web/CHANGELOG.md` updates with the implementation.
+
+## Acceptance Criteria
+
+- [ ] Markdown content created for About at `content/pages/about.md` can be built and rendered by the web app.
+- [ ] The web app serves the standalone About content at `/about`.
+- [ ] About rendering does not require the page to appear as a listed content section.
+- [ ] Existing `posts` and `technical-sessions` listing/detail routes continue to behave as before.
+- [ ] The first About rendering slice reuses existing layout/rendering behavior where practical instead of introducing unnecessary page-system complexity.
+- [ ] Focused tests or route/build verification cover the standalone About path and guard the affected content behavior.
+- [ ] Required web version and `web/CHANGELOG.md` updates are included with the implementation.
+
+## Implementation Notes
+
+- Related scope decision: `change-requests/CR-006-define-content-operations-app-scope-and-workflows.md`.
+- Generator source for the About output path: `change-requests/CR-015-template-driven-content-generator.md`.
+- Current content build entrypoint: `web/scripts/build-posts.ts`.
+- Current runtime content routes: `web/src/routes/[section]/index.tsx` and `web/src/routes/[section]/[slug].tsx`.
+- Current rendering schemas: `web/src/schemas/content-schemas.ts`.
+- Metadata validation, preview/build readiness, Electron UI, and generic standalone page authoring remain follow-up work.
+
+## Outcome
+
+Pending.

--- a/change-requests/index.md
+++ b/change-requests/index.md
@@ -28,6 +28,8 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 | CR-012 | Decide parser roadmap for markdown processing | Proposed | Medium | Content Pipeline | 2026-05-06 | Pending detail |
 | CR-013 | Add CI content validation checks | Proposed | Medium | Quality | 2026-05-06 | Pending detail |
 | CR-014 | Reassess generated content artifact strategy | Proposed | Medium | Architecture | 2026-05-06 | Pending detail |
+| CR-015 | Template-driven content generator | Done | High | Content Operations | 2026-05-21 | [CR-015-template-driven-content-generator.md](./CR-015-template-driven-content-generator.md) |
+| CR-016 | Render standalone About content | Planned | High | Web Content | 2026-05-21 | [CR-016-render-standalone-about-content.md](./CR-016-render-standalone-about-content.md) |
 
 ## Status Guide
 

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -1,0 +1,124 @@
+---
+title: My Life in Digital
+description: "A personal digital space for software, AI experiments, side projects, and reflections on building with curiosity."
+contentType: "about"
+layout: "article"
+slug: "about"
+draft: true
+---
+
+# My Life in Digital
+
+## Introduction
+
+My Life in Digital is a personal space for ideas, experiments, projects, and reflections connected to software, AI, creativity, and the messy reality of building things while living an actual life.
+
+It is not just a portfolio.
+
+It is not just a blog.
+
+It is a place where digital threads come together: the things I am learning, the tools I am building, the questions I am asking, and the small experiments that may or may not become something bigger.
+
+## Why This Exists
+
+I created My Life in Digital because curiosity needs somewhere to go.
+
+A lot of useful ideas start small. A note. A prototype. A half-finished repo. A question that keeps coming back. This site gives those ideas a home.
+
+Some of the work here will be practical. Some of it will be exploratory. Some of it may simply be me thinking out loud about technology, work, creativity, and what it means to keep building over time.
+
+The goal is not to look polished at every step.
+
+The goal is to keep moving.
+
+## Digital Threads
+
+The idea behind this space is simple: every project, article, experiment, and reflection is a thread.
+
+Some threads are technical.
+
+Some are creative.
+
+Some are personal.
+
+Over time, those threads form a picture of where my curiosity has taken me.
+
+## What I Explore Here
+
+This site focuses on areas that keep pulling my attention back:
+
+- software engineering
+- JavaScript and TypeScript
+- React, Next.js, and modern web development
+- AI-assisted development
+- agentic workflows and automation
+- content systems and markdown-driven publishing
+- side projects and digital products
+- lessons learned while building in public
+
+## Current Focus
+
+At the moment, I am especially interested in building practical AI-enabled tools that solve real problems.
+
+Not hype for the sake of hype.
+
+Not another shiny demo that dies after a weekend.
+
+I am interested in the point where useful software, thoughtful design, and AI meet.
+
+That includes experiments around product cataloguing, content workflows, developer tools, and small systems that make everyday work easier.
+
+## How I Think About Building
+
+I believe in building small, learning fast, and improving as you go.
+
+Perfect plans are overrated.
+
+Shipping something imperfect teaches more than endlessly polishing something nobody sees.
+
+My approach is simple:
+
+1. notice an idea
+2. shape it into something small
+3. build enough to learn from it
+4. document the process
+5. keep what works
+6. throw away what does not
+
+That is the rhythm I want this site to capture.
+
+## Beyond Code
+
+My Life in Digital also connects to a broader creative journey.
+
+I am interested in how technology supports real people, small businesses, creative work, and personal growth. Software is not only about frameworks, databases, and deployments. It is also about solving problems, creating opportunities, and making ideas easier to share.
+
+The best technology disappears into the work it helps people do.
+
+## What You Will Find Here
+
+You can expect a mix of:
+
+- technical articles
+- project notes
+- AI experiments
+- build logs
+- reflections on software engineering
+- thoughts on career, creativity, and sustainable growth
+- practical lessons from real-world development
+
+Some posts will be polished.
+
+Others will be rougher working notes.
+
+Both have value.
+
+## The Bigger Idea
+
+My Life in Digital is about staying curious and continuing to build.
+
+It is about becoming better through practice, not waiting until everything feels perfect.
+
+It is about following the threads and seeing where they lead.
+
+Because sometimes the small experiment you almost ignored becomes the thing that opens the next door.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@types/node": "^25.0.3",
         "ts-node": "^10.9.2",
+        "tsx": "^4.22.3",
         "typescript": "^5.9.3"
       }
     },
@@ -32,461 +33,12 @@
         "typescript": "^5.9.3"
       }
     },
-    "experiments/ts-core-utils/node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "experiments/ts-core-utils/node_modules/@types/node": {
       "version": "24.10.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/esbuild": {
-      "version": "0.25.12",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "experiments/ts-core-utils/node_modules/tsx": {
-      "version": "4.20.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
       }
     },
     "experiments/ts-core-utils/node_modules/zod": {
@@ -1455,9 +1007,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -1472,9 +1024,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -1484,15 +1036,14 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -1502,15 +1053,14 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -1520,15 +1070,14 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -1538,15 +1087,14 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -1556,15 +1104,14 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1574,15 +1121,14 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -1592,15 +1138,14 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -1610,15 +1155,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -1628,15 +1172,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -1646,15 +1189,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -1664,15 +1206,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -1682,15 +1223,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -1700,15 +1240,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1718,15 +1257,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -1736,15 +1274,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -1754,15 +1291,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -1777,9 +1313,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -1789,15 +1325,14 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -1812,9 +1347,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -1824,15 +1359,14 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
       ],
@@ -1847,9 +1381,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -1859,15 +1393,14 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -1877,15 +1410,14 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -1895,15 +1427,14 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -1913,7 +1444,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3318,13 +2848,12 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3332,104 +2861,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -5718,6 +5175,25 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5935,378 +5411,6 @@
         "node": ">=16"
       }
     },
-    "web/node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "web/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "web/node_modules/@types/marked": {
       "version": "6.0.0",
       "deprecated": "This is a stub types definition. marked provides its own type definitions, so you do not need this installed.",
@@ -6337,57 +5441,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "web/node_modules/esbuild": {
-      "version": "0.25.12",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
-      }
-    },
-    "web/node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "web/node_modules/marked": {
@@ -6424,32 +5477,6 @@
       },
       "engines": {
         "node": ">=16.13"
-      }
-    },
-    "web/node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "web/node_modules/tsx": {
-      "version": "4.20.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
       }
     },
     "web/node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mylifeindigital",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "description": "My Life In Digital monorepo",
   "workspaces": [
     "web",
@@ -12,8 +13,11 @@
     "build:utils": "npm run build --workspace=ts-core-utils",
     "build:web": "npm run build --workspace=web",
     "deploy": "npm run update-date -- --all && npm run deploy --workspace=web",
-    "new-session": "npx ts-node scripts/new-session.ts",
-    "update-date": "npx ts-node scripts/update-date.ts"
+    "new-content": "tsx scripts/new-content.ts",
+    "new-session": "tsx scripts/new-session.ts",
+    "test:scripts": "tsx --test scripts/content/*.test.ts",
+    "typecheck:scripts": "tsc",
+    "update-date": "tsx scripts/update-date.ts"
   },
   "keywords": [],
   "author": "",
@@ -21,6 +25,7 @@
   "devDependencies": {
     "@types/node": "^25.0.3",
     "ts-node": "^10.9.2",
+    "tsx": "^4.22.3",
     "typescript": "^5.9.3"
   }
 }

--- a/scripts/content/generate-content.test.ts
+++ b/scripts/content/generate-content.test.ts
@@ -1,0 +1,97 @@
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, it } from "node:test";
+import { createContentFile } from "./generate-content.js";
+import { getContentTemplate } from "./template-registry.js";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../.."
+);
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const temporaryRoot of temporaryRoots.splice(0)) {
+    fs.rmSync(temporaryRoot, { force: true, recursive: true });
+  }
+});
+
+describe("content templates", () => {
+  it("selects the MVP post and about templates", () => {
+    assert.equal(getContentTemplate("post").outputDirectory, "content/posts");
+    assert.equal(getContentTemplate("about").outputDirectory, "content/pages");
+    assert.throws(() => getContentTemplate("page"), /Unknown content template/);
+    assert.throws(() => getContentTemplate("toString"), /Unknown content template/);
+  });
+});
+
+describe("createContentFile", () => {
+  it("creates draft post content from the title slug", () => {
+    const outputRoot = createTemporaryRoot();
+    const result = createContentFile({
+      templateId: "post",
+      title: 'Learning "ESM"',
+      repositoryRoot,
+      outputRoot,
+      now: new Date("2026-05-21T12:00:00"),
+    });
+
+    assert.equal(result.slug, "learning-esm");
+    assert.equal(
+      result.relativeOutputPath,
+      path.join("content", "posts", "learning-esm.md")
+    );
+    assert.match(result.content, /title: "Learning \\"ESM\\""/);
+    assert.match(result.content, /date: "2026-05-21"/);
+    assert.match(result.content, /draft: true/);
+    assert.match(result.content, /contentType: "post"/);
+    assert.equal(fs.readFileSync(result.outputPath, "utf8"), result.content);
+  });
+
+  it("creates the standalone About draft at its fixed MVP path", () => {
+    const outputRoot = createTemporaryRoot();
+    const result = createContentFile({
+      templateId: "about",
+      title: "About My Life In Digital",
+      repositoryRoot,
+      outputRoot,
+    });
+
+    assert.equal(result.slug, "about");
+    assert.equal(
+      result.relativeOutputPath,
+      path.join("content", "pages", "about.md")
+    );
+    assert.match(result.content, /slug: "about"/);
+    assert.match(result.content, /draft: true/);
+    assert.match(result.content, /contentType: "about"/);
+  });
+
+  it("refuses to overwrite an existing generated file", () => {
+    const outputRoot = createTemporaryRoot();
+    const options = {
+      templateId: "post",
+      title: "Existing Draft",
+      repositoryRoot,
+      outputRoot,
+    };
+
+    createContentFile(options);
+
+    assert.throws(
+      () => createContentFile(options),
+      /Content file already exists/
+    );
+  });
+});
+
+function createTemporaryRoot(): string {
+  const temporaryRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "mylifeindigital-content-")
+  );
+  temporaryRoots.push(temporaryRoot);
+  return temporaryRoot;
+}

--- a/scripts/content/generate-content.ts
+++ b/scripts/content/generate-content.ts
@@ -1,0 +1,124 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  getContentTemplate,
+  type ContentTemplateDefinition,
+} from "./template-registry.js";
+
+export interface CreateContentFileOptions {
+  templateId: string;
+  title: string;
+  repositoryRoot: string;
+  now?: Date;
+  outputRoot?: string;
+  templateRoot?: string;
+}
+
+export interface CreatedContentFile {
+  template: ContentTemplateDefinition;
+  title: string;
+  slug: string;
+  outputPath: string;
+  relativeOutputPath: string;
+  content: string;
+}
+
+interface RenderValues {
+  date: string;
+  slug: string;
+  title: string;
+  titleYaml: string;
+}
+
+export function slugifyTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function createContentFile(options: CreateContentFileOptions): CreatedContentFile {
+  const template = getContentTemplate(options.templateId);
+  const title = options.title.trim();
+
+  if (!title) {
+    throw new Error("Title is required.");
+  }
+
+  const now = options.now ?? new Date();
+  const outputRoot = options.outputRoot ?? options.repositoryRoot;
+  const templateRoot = options.templateRoot ?? options.repositoryRoot;
+  const { filename, slug } = getOutputIdentity(template, title);
+  const templatePath = path.resolve(templateRoot, template.templatePath);
+  const outputPath = path.resolve(outputRoot, template.outputDirectory, filename);
+  const templateContent = fs.readFileSync(templatePath, "utf8");
+  const content = renderTemplate(templateContent, {
+    date: formatDate(now),
+    slug,
+    title,
+    titleYaml: JSON.stringify(title),
+  });
+
+  if (fs.existsSync(outputPath)) {
+    throw new Error(`Content file already exists: ${outputPath}`);
+  }
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, content, { encoding: "utf8", flag: "wx" });
+
+  return {
+    template,
+    title,
+    slug,
+    outputPath,
+    relativeOutputPath: path.relative(outputRoot, outputPath),
+    content,
+  };
+}
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function getOutputIdentity(
+  template: ContentTemplateDefinition,
+  title: string
+): { filename: string; slug: string } {
+  if (template.filenameStrategy.kind === "fixed") {
+    return {
+      filename: template.filenameStrategy.filename,
+      slug: template.filenameStrategy.slug,
+    };
+  }
+
+  const slug = slugifyTitle(title);
+  if (!slug) {
+    throw new Error(`Title "${title}" does not produce a filename slug.`);
+  }
+
+  return {
+    filename: `${slug}.md`,
+    slug,
+  };
+}
+
+function renderTemplate(templateContent: string, values: RenderValues): string {
+  const replacements: Record<string, string> = {
+    DATE: values.date,
+    SLUG: values.slug,
+    TITLE: values.title,
+    TITLE_YAML: values.titleYaml,
+  };
+
+  return templateContent.replace(/\{\{([A-Z_]+)\}\}/g, (placeholder, key: string) => {
+    const replacement = replacements[key];
+    if (replacement === undefined) {
+      throw new Error(`Unsupported template placeholder ${placeholder}.`);
+    }
+
+    return replacement;
+  });
+}

--- a/scripts/content/template-registry.ts
+++ b/scripts/content/template-registry.ts
@@ -1,0 +1,100 @@
+export type ContentTemplateId = "post" | "about";
+
+export interface ContentTemplatePromptField {
+  key: "title";
+  label: string;
+  required: true;
+}
+
+export type ContentTemplateFilenameStrategy =
+  | {
+      kind: "title-slug";
+    }
+  | {
+      kind: "fixed";
+      filename: string;
+      slug: string;
+    };
+
+export interface ContentTemplateDefinition {
+  id: ContentTemplateId;
+  label: string;
+  templatePath: string;
+  outputDirectory: string;
+  promptFields: ContentTemplatePromptField[];
+  filenameStrategy: ContentTemplateFilenameStrategy;
+  requiredMetadata: string[];
+  optionalMetadata: string[];
+  layouts: string[];
+}
+
+export const contentTemplates = {
+  post: {
+    id: "post",
+    label: "Post",
+    templatePath: "scripts/templates/post.md",
+    outputDirectory: "content/posts",
+    promptFields: [
+      {
+        key: "title",
+        label: "Title",
+        required: true,
+      },
+    ],
+    filenameStrategy: {
+      kind: "title-slug",
+    },
+    requiredMetadata: [
+      "title",
+      "date",
+      "draft",
+      "contentType",
+      "layout",
+      "section",
+    ],
+    optionalMetadata: [
+      "updated",
+      "tags",
+      "description",
+      "heroSection",
+      "author",
+    ],
+    layouts: ["article"],
+  },
+  about: {
+    id: "about",
+    label: "About",
+    templatePath: "scripts/templates/about.md",
+    outputDirectory: "content/pages",
+    promptFields: [
+      {
+        key: "title",
+        label: "Title",
+        required: true,
+      },
+    ],
+    filenameStrategy: {
+      kind: "fixed",
+      filename: "about.md",
+      slug: "about",
+    },
+    requiredMetadata: ["title", "draft", "contentType", "layout", "slug"],
+    optionalMetadata: ["updated", "description"],
+    layouts: ["article"],
+  },
+} satisfies Record<ContentTemplateId, ContentTemplateDefinition>;
+
+export const contentTemplateIds = Object.keys(contentTemplates) as ContentTemplateId[];
+
+export function getContentTemplate(templateId: string): ContentTemplateDefinition {
+  if (isContentTemplateId(templateId)) {
+    return contentTemplates[templateId];
+  }
+
+  const knownTemplates = contentTemplateIds.join(", ");
+  throw new Error(`Unknown content template "${templateId}". Choose: ${knownTemplates}.`);
+}
+
+function isContentTemplateId(templateId: string): templateId is ContentTemplateId {
+  return Object.prototype.hasOwnProperty.call(contentTemplates, templateId);
+}

--- a/scripts/new-content.ts
+++ b/scripts/new-content.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env -S npx tsx
+
+import * as path from "node:path";
+import * as readline from "node:readline";
+import { fileURLToPath } from "node:url";
+import { createContentFile } from "./content/generate-content.js";
+import {
+  contentTemplateIds,
+  getContentTemplate,
+  type ContentTemplateDefinition,
+} from "./content/template-registry.js";
+
+interface CliArguments {
+  help: boolean;
+  templateId?: string;
+  title?: string;
+}
+
+async function main(): Promise<void> {
+  const args = parseArguments(process.argv.slice(2));
+
+  if (args.help) {
+    showHelp();
+    return;
+  }
+
+  const template = await selectTemplate(args.templateId);
+  const title = args.title ?? await prompt(getTitlePrompt(template));
+  const result = createContentFile({
+    templateId: template.id,
+    title,
+    repositoryRoot: getRepositoryRoot(),
+  });
+
+  console.log(`\nCreated ${result.template.label} draft: ${result.relativeOutputPath}\n`);
+}
+
+function parseArguments(args: string[]): CliArguments {
+  const result: CliArguments = { help: false };
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+
+    if (argument === "-h" || argument === "--help") {
+      result.help = true;
+      continue;
+    }
+
+    if (argument === "--type") {
+      result.templateId = readArgumentValue(args, ++index, argument);
+      continue;
+    }
+
+    if (argument === "--title") {
+      result.title = readArgumentValue(args, ++index, argument);
+      continue;
+    }
+
+    throw new Error(`Unknown argument "${argument}".`);
+  }
+
+  return result;
+}
+
+function readArgumentValue(args: string[], index: number, argument: string): string {
+  const value = args[index];
+
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${argument} requires a value.`);
+  }
+
+  return value;
+}
+
+function getRepositoryRoot(): string {
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(scriptDirectory, "..");
+}
+
+async function selectTemplate(templateId?: string): Promise<ContentTemplateDefinition> {
+  const selectedTemplateId =
+    templateId ?? await prompt(`Content type (${contentTemplateIds.join("/")}): `);
+
+  return getContentTemplate(selectedTemplateId);
+}
+
+function getTitlePrompt(template: ContentTemplateDefinition): string {
+  const titleField = template.promptFields.find((field) => field.key === "title");
+  return `${titleField?.label ?? "Title"}: `;
+}
+
+function prompt(question: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+function showHelp(): void {
+  console.log(`
+New Content Generator
+
+Usage:
+  npm run new-content
+  npm run new-content -- --type post --title "My New Post"
+  npm run new-content -- --type about --title "About"
+
+Options:
+  --type <${contentTemplateIds.join("|")}>  Template to generate
+  --title <title>      Title for the new draft
+  -h, --help           Show this help message
+`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Error: ${message}`);
+  process.exitCode = 1;
+});

--- a/scripts/new-session.ts
+++ b/scripts/new-session.ts
@@ -1,11 +1,13 @@
-#!/usr/bin/env npx ts-node
+#!/usr/bin/env -S npx tsx
 
 import * as fs from "fs";
 import * as path from "path";
 import * as readline from "readline";
+import { fileURLToPath } from "url";
 
-const CONTENT_DIR = path.join(__dirname, "..", "content", "technical-sessions");
-const TEMPLATE_PATH = path.join(__dirname, "templates", "technical-session.md");
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const CONTENT_DIR = path.join(SCRIPT_DIR, "..", "content", "technical-sessions");
+const TEMPLATE_PATH = path.join(SCRIPT_DIR, "templates", "technical-session.md");
 
 function prompt(question: string): Promise<string> {
   const rl = readline.createInterface({

--- a/scripts/templates/about.md
+++ b/scripts/templates/about.md
@@ -1,0 +1,14 @@
+---
+title: {{TITLE_YAML}}
+description: ""
+contentType: "about"
+layout: "article"
+slug: "{{SLUG}}"
+draft: true
+---
+
+# {{TITLE}}
+
+## Introduction
+
+Start writing here.

--- a/scripts/templates/post.md
+++ b/scripts/templates/post.md
@@ -1,0 +1,15 @@
+---
+title: {{TITLE_YAML}}
+date: "{{DATE}}"
+updated: "{{DATE}}"
+author: "Fredrik Erasmus"
+section: "posts"
+contentType: "post"
+layout: "article"
+tags: []
+draft: true
+---
+
+# {{TITLE}}
+
+Start writing here.

--- a/scripts/update-date.ts
+++ b/scripts/update-date.ts
@@ -1,9 +1,11 @@
-#!/usr/bin/env npx ts-node
+#!/usr/bin/env -S npx tsx
 
 import * as fs from "fs";
 import * as path from "path";
+import { fileURLToPath } from "url";
 
-const CONTENT_DIR = path.join(__dirname, "..", "content");
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const CONTENT_DIR = path.join(SCRIPT_DIR, "..", "content");
 
 function getToday(): string {
   const now = new Date();
@@ -136,4 +138,3 @@ main().catch((err) => {
   console.error("Error:", err);
   process.exit(1);
 });
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,16 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2020"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "outDir": "./dist"
+    "noEmit": true
   },
   "include": ["scripts/**/*"],
   "exclude": ["node_modules", "web", "experiments"]
 }
-


### PR DESCRIPTION
## Summary

Implements `CR-015` by adding the first template-driven root content generation workflow for MVP content operations.

This change adds a reusable generator for draft `post` and `about` Markdown content, moves root content-tooling scripts onto an ESM-aligned TypeScript execution path, and keeps the existing technical-session and date-update authoring workflows available.

## What Changed

- Added a root `new-content` command for generating Markdown content from templates.
- Added a small template registry/config for the MVP `post` and `about` flows.
- Added reusable generator logic outside the web runtime so later content operations work can reuse it.
- Added Markdown templates for:
  - post drafts at `content/posts/{title-slug}.md`
  - standalone About drafts at `content/pages/about.md`
- Defaulted generated content to `draft: true`.
- Refused overwriting an existing generated target file.
- Moved root script execution from `ts-node` to `tsx`.
- Updated root TypeScript configuration to an ESM-aligned `NodeNext` path with typecheck-only output.
- Preserved the existing `new-session` and `update-date` commands after the runtime change.
- Added focused tests for template selection, generated file behavior, draft-safe defaults, and overwrite protection.
- Documented the new content authoring commands and closed out `CR-015`.

## Why

`CR-006` identified template-driven content creation as the first practical content operations slice for listed posts and standalone About content.

The repository already had a technical-session generator, but that workflow was specific to one content shape. This change introduces the smallest reusable generator model needed to prove content creation for the MVP content focus without coupling the operation to the web app or jumping into Electron UI work.

## Authoring Commands

```bash
npm run new-content -- --type post --title "My New Post"
npm run new-content -- --type about --title "About"
```

Existing authoring commands remain available:

```bash
npm run new-session
npm run update-date -- content/posts/my-post.md
```

## Validation

- `npm run typecheck:scripts`
- `npm run test:scripts`
- `npm run new-content -- --help`
- `npm run new-session -- --help`
- `npm run update-date -- --help`
- `git diff --check`

## Notes

- The About generator path is intentionally fixed to `content/pages/about.md` for this MVP slice.
- Rendering standalone About content in the web app is deferred to the next change request.
- Metadata validation, preview/build readiness, Electron UI, and template-authoring UI remain out of scope.