### PR TITLE
CR-016 added about routing/rendering

### DIFF
--- a/change-requests/CR-016-render-standalone-about-content.md
+++ b/change-requests/CR-016-render-standalone-about-content.md
@@ -1,6 +1,6 @@
 # CR-016: Render Standalone About Content
 
-Status: Planned  
+Status: Done
 Priority: High  
 Area: Web Content  
 Created: 2026-05-21
@@ -31,13 +31,13 @@ Because this changes the web runtime and user-facing behavior, include the requi
 
 ## Acceptance Criteria
 
-- [ ] Markdown content created for About at `content/pages/about.md` can be built and rendered by the web app.
-- [ ] The web app serves the standalone About content at `/about`.
-- [ ] About rendering does not require the page to appear as a listed content section.
-- [ ] Existing `posts` and `technical-sessions` listing/detail routes continue to behave as before.
-- [ ] The first About rendering slice reuses existing layout/rendering behavior where practical instead of introducing unnecessary page-system complexity.
-- [ ] Focused tests or route/build verification cover the standalone About path and guard the affected content behavior.
-- [ ] Required web version and `web/CHANGELOG.md` updates are included with the implementation.
+- [x] Markdown content created for About at `content/pages/about.md` can be built and rendered by the web app.
+- [x] The web app serves the standalone About content at `/about`.
+- [x] About rendering does not require the page to appear as a listed content section.
+- [x] Existing `posts` and `technical-sessions` listing/detail routes continue to behave as before.
+- [x] The first About rendering slice reuses existing layout/rendering behavior where practical instead of introducing unnecessary page-system complexity.
+- [x] Focused tests or route/build verification cover the standalone About path and guard the affected content behavior.
+- [x] Required web version and `web/CHANGELOG.md` updates are included with the implementation.
 
 ## Implementation Notes
 
@@ -50,4 +50,16 @@ Because this changes the web runtime and user-facing behavior, include the requi
 
 ## Outcome
 
-Pending.
+Implemented the first standalone authored page path for the web app:
+
+- Added build-time handling for the fixed About source at `content/pages/about.md` so it is processed with the Markdown pipeline into standalone page data instead of a listed `pages` section.
+- Added a dedicated `/about` runtime route and cache lookup while keeping listed post and technical-session routing unchanged.
+- Reused the article renderer with standalone Home navigation so About does not link back to a synthetic section route.
+- Published the checked-in About content by setting `draft: false`.
+- Bumped the web app to `0.3.2` and recorded the change in `web/CHANGELOG.md`.
+
+Validated with:
+
+- `cd web && npm run build:posts`
+- `cd web && npx tsc --noEmit`
+- Local browser route checks for `/about`, `/posts`, `/technical-sessions`, `/pages`, one post detail route, and one technical-session detail route.

--- a/change-requests/index.md
+++ b/change-requests/index.md
@@ -29,7 +29,7 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 | CR-013 | Add CI content validation checks | Proposed | Medium | Quality | 2026-05-06 | Pending detail |
 | CR-014 | Reassess generated content artifact strategy | Proposed | Medium | Architecture | 2026-05-06 | Pending detail |
 | CR-015 | Template-driven content generator | Done | High | Content Operations | 2026-05-21 | [CR-015-template-driven-content-generator.md](./CR-015-template-driven-content-generator.md) |
-| CR-016 | Render standalone About content | Planned | High | Web Content | 2026-05-21 | [CR-016-render-standalone-about-content.md](./CR-016-render-standalone-about-content.md) |
+| CR-016 | Render standalone About content | Done | High | Web Content | 2026-05-21 | [CR-016-render-standalone-about-content.md](./CR-016-render-standalone-about-content.md) |
 
 ## Status Guide
 

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -4,7 +4,7 @@ description: "A personal digital space for software, AI experiments, side projec
 contentType: "about"
 layout: "article"
 slug: "about"
-draft: true
+draft: false
 ---
 
 # My Life in Digital

--- a/package-lock.json
+++ b/package-lock.json
@@ -5276,7 +5276,7 @@
       }
     },
     "web": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "ISC",
       "dependencies": {
         "gray-matter": "^4.0.3",

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the web app will be documented in this file.
 
+## [0.3.2] - 2026-05-21
+
+### Added
+
+- Standalone About content authored in Markdown now renders at `/about`
+
 ## [0.3.1] - 2026-03-01
 
 ### Fixed
@@ -81,4 +87,3 @@ All notable changes to the web app will be documented in this file.
 ### Added
 
 - Display update date in article metadata when the `updated` field is present in frontmatter
-

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Hono markdown web application for Cloudflare Workers",
   "type": "module",
   "main": "dist/index.js",

--- a/web/scripts/build-posts.ts
+++ b/web/scripts/build-posts.ts
@@ -43,6 +43,14 @@ const dryRun = args.includes('--dry-run');
 // Track ImageGeneratorProcessor for manifest saving
 let imageGeneratorProcessor: ImageGeneratorProcessor | null = null;
 
+const standalonePageSources = [
+    {
+        slug: 'about',
+        section: 'pages',
+        relativePath: join('pages', 'about.md'),
+    },
+] as const;
+
 /**
  * Create the markdown processing pipeline.
  */
@@ -149,6 +157,9 @@ async function getAllSections(
     contentDir: string
 ): Promise<Section[]> {
     const sections: Section[] = [];
+    const standaloneSections = new Set(
+        standalonePageSources.map(page => page.section)
+    );
 
     if (!existsSync(contentDir)) {
         console.warn(`⚠️ Content directory not found: ${contentDir}`);
@@ -161,7 +172,7 @@ async function getAllSections(
         const entryPath = join(contentDir, entry);
         const stat = statSync(entryPath);
 
-        if (stat.isDirectory()) {
+        if (stat.isDirectory() && !standaloneSections.has(entry)) {
             console.log(`  📁 Section: ${entry}`);
             const sectionSlug = entry;
             const items = await getSectionContent(pipeline, entryPath, sectionSlug);
@@ -178,6 +189,42 @@ async function getAllSections(
 
     // Sort sections alphabetically by title
     return sections.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+/**
+ * Get standalone pages that render outside listed section routes.
+ */
+async function getStandalonePages(
+    pipeline: MarkdownProcessingPipeline,
+    contentDir: string
+): Promise<ContentItem[]> {
+    const pages: ContentItem[] = [];
+
+    for (const page of standalonePageSources) {
+        const filePath = join(contentDir, page.relativePath);
+
+        if (!existsSync(filePath)) {
+            console.warn(`⚠️ Standalone page not found: ${filePath}`);
+            continue;
+        }
+
+        const item = await parseMarkdownFile(
+            pipeline,
+            filePath,
+            page.slug,
+            page.section
+        );
+
+        if (item === null) {
+            console.log(`  📝 [draft] Standalone page: ${page.relativePath}`);
+            continue;
+        }
+
+        pages.push(item);
+        console.log(`  📄 Standalone page: ${page.relativePath}`);
+    }
+
+    return pages;
 }
 
 /**
@@ -223,11 +270,13 @@ async function main(): Promise<void> {
 
     const pipeline = createPipeline();
     const sections = await getAllSections(pipeline, contentDir);
+    const standalonePages = await getStandalonePages(pipeline, contentDir);
     const allItems = sections.flatMap(section => section.items);
 
     const siteContent: SiteContent = {
         sections,
         allItems,
+        standalonePages,
     };
 
     // Save image manifest if we generated images
@@ -241,6 +290,7 @@ async function main(): Promise<void> {
     console.log(`✅ Generated content data:`);
     console.log(`   - ${sections.length} section(s)`);
     console.log(`   - ${allItems.length} item(s) total`);
+    console.log(`   - ${standalonePages.length} standalone page(s)`);
     sections.forEach(section => {
         console.log(`   - ${section.title}: ${section.items.length} item(s)`);
     });

--- a/web/src/components/layouts/ArticleLayout.tsx
+++ b/web/src/components/layouts/ArticleLayout.tsx
@@ -12,8 +12,12 @@ import type { DisplaySchema } from '../../schemas/content-schemas.js';
 
 interface ArticleLayoutProps {
   item: ContentItem;
-  section: Section;
+  section?: Section;
   schema: DisplaySchema;
+  backLink?: {
+    href: string;
+    label: string;
+  };
 }
 
 function formatDate(dateString?: string): string {
@@ -53,10 +57,16 @@ function TocSidebar({ toc }: { toc?: TocEntry[] }) {
   );
 }
 
-export function ArticleLayout({ item, section, schema }: ArticleLayoutProps) {
+export function ArticleLayout({ item, section, schema, backLink }: ArticleLayoutProps) {
   const hasToc = item.toc && item.toc.length > 0;
   const heroImage = item.metadata.image;
   const heroImageAlt = item.metadata.imageAlt || `Cover image for ${item.metadata.title}`;
+  const navigation = backLink ?? (section
+    ? {
+        href: `/${section.slug}`,
+        label: section.title,
+      }
+    : null);
 
   return (
     <div class={`article-wrapper ${hasToc ? 'has-toc' : ''}`}>
@@ -64,7 +74,9 @@ export function ArticleLayout({ item, section, schema }: ArticleLayoutProps) {
 
       <article class="article">
         <header class="article-header">
-          <a href={`/${section.slug}`} class="back-link">← {section.title}</a>
+          {navigation && (
+            <a href={navigation.href} class="back-link">← {navigation.label}</a>
+          )}
 
           {heroImage && (
             <div class="article-hero">
@@ -105,10 +117,11 @@ export function ArticleLayout({ item, section, schema }: ArticleLayoutProps) {
         <div class="post-content">{raw(item.html)}</div>
 
         <footer class="article-footer">
-          <a href={`/${section.slug}`} class="btn">← Back to {section.title}</a>
+          {navigation && (
+            <a href={navigation.href} class="btn">← Back to {navigation.label}</a>
+          )}
         </footer>
       </article>
     </div>
   );
 }
-

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { jsxRenderer } from 'hono/jsx-renderer';
 import { indexRoute } from './routes/index.js';
+import { aboutRoute } from './routes/about.js';
 import { sectionRoute } from './routes/[section]/index.js';
 import { contentItemRoute } from './routes/[section]/[slug].js';
 import { adminApp, adminApi } from './routes/admin/index.js';
@@ -22,6 +23,12 @@ app.route('/api/admin', adminApi);
 app.get('/', (c) => {
     const config = getConfig(c.env);
     return c.render(indexRoute(config));
+});
+
+// Standalone authored pages must be registered before dynamic section routes
+app.get('/about', (c) => {
+    const config = getConfig(c.env);
+    return c.render(aboutRoute(config));
 });
 
 // Section listing route (e.g., /posts, /technical-sessions)

--- a/web/src/routes/about.tsx
+++ b/web/src/routes/about.tsx
@@ -1,0 +1,39 @@
+import { Layout } from '../components/Layout.js';
+import { ArticleLayout } from '../components/layouts/ArticleLayout.js';
+import { getSchemaForContent } from '../schemas/content-schemas.js';
+import type { AppConfig } from '../config.js';
+import { getAllSections, getStandalonePageBySlug } from '../utils/post-cache.js';
+
+export function aboutRoute(config: AppConfig) {
+    const page = getStandalonePageBySlug('about');
+    const sections = getAllSections();
+    const { siteTitle, socialLinks } = config;
+
+    if (!page) {
+        return (
+            <Layout title={`About | ${siteTitle}`} siteTitle={siteTitle} sections={sections} socialLinks={socialLinks}>
+                <div class="not-found">
+                    <h2>404</h2>
+                    <p>The About page isn't published yet.</p>
+                    <a href="/" class="btn">← Back to Home</a>
+                </div>
+            </Layout>
+        );
+    }
+
+    const layoutOverride = page.metadata.layout as string | undefined;
+    const schema = getSchemaForContent(page.section, layoutOverride);
+
+    return (
+        <Layout title={`${page.metadata.title} | ${siteTitle}`} siteTitle={siteTitle} sections={sections} socialLinks={socialLinks}>
+            <ArticleLayout
+                item={page}
+                schema={schema}
+                backLink={{
+                    href: '/',
+                    label: 'Home',
+                }}
+            />
+        </Layout>
+    );
+}

--- a/web/src/utils/markdown.ts
+++ b/web/src/utils/markdown.ts
@@ -46,6 +46,7 @@ export interface Section {
 export interface SiteContent {
     sections: Section[];
     allItems: ContentItem[];
+    standalonePages: ContentItem[];
 }
 
 // Backward compatibility aliases

--- a/web/src/utils/post-cache.ts
+++ b/web/src/utils/post-cache.ts
@@ -5,6 +5,7 @@ import { siteContent, postsData } from './posts-data.js';
 const contentCache: SiteContent = siteContent;
 const sectionsCache: Section[] = contentCache.sections;
 const allItemsCache: ContentItem[] = contentCache.allItems;
+const standalonePagesCache: ContentItem[] = contentCache.standalonePages;
 
 // Build lookup maps for fast access
 const itemsBySectionCache: Map<string, ContentItem[]> = new Map(
@@ -15,6 +16,9 @@ const itemBySlugCache: Map<string, ContentItem> = new Map(
 );
 const sectionBySlugCache: Map<string, Section> = new Map(
     sectionsCache.map(section => [section.slug, section])
+);
+const standalonePageBySlugCache: Map<string, ContentItem> = new Map(
+    standalonePagesCache.map(page => [page.slug, page])
 );
 
 /**
@@ -57,6 +61,13 @@ export function getItemBySlug(sectionSlug: string, itemSlug: string): ContentIte
  */
 export function getAllItems(): ContentItem[] {
     return [...allItemsCache];
+}
+
+/**
+ * Get a standalone page by its stable slug.
+ */
+export function getStandalonePageBySlug(slug: string): ContentItem | null {
+    return standalonePageBySlugCache.get(slug) || null;
 }
 
 /**

--- a/web/src/version.ts
+++ b/web/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.3.1';
+export const VERSION = '0.3.2';


### PR DESCRIPTION
## Summary

Implements CR-016 by adding the first standalone authored page path for the web app.

The About Markdown source at `content/pages/about.md` is now processed by the existing content pipeline and rendered at `/about` without becoming a listed `pages` section.

## Changes

- Added standalone page data support to the generated site content model.
- Updated the content build script to process the fixed About source separately from listed sections.
- Added a standalone About cache lookup and `/about` route.
- Reused the existing article layout with standalone Home navigation for About.
- Published the checked-in About content by setting `draft: false`.
- Kept existing `posts` and `technical-sessions` listing/detail route behavior unchanged.
- Bumped the web app version to `0.3.2` and updated `web/CHANGELOG.md`.
- Marked CR-016 as done and recorded the implementation outcome.

## Verification

- `cd web && npm run build:posts`
- `cd web && npx tsc --noEmit`
- Local browser checks:
  - `/about` renders the authored About content
  - `/posts` still renders
  - `/technical-sessions` still renders
  - `/pages` does not become a listed section
  - Existing post and technical-session detail routes still resolve
- `git diff --check`

## Notes

- This keeps the first standalone-page slice intentionally narrow around About.
- Generic standalone page routing and navigation decisions such as adding an About top-nav link remain follow-up work.