### PR TITLE
Cr 007 single vs split content repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,26 @@
 
 Repository-level changes for `mylifeindigital`. Web app release changes are tracked separately in `web/CHANGELOG.md`.
 
+## 2026-06-16
+
+### Added
+
+- Added `CR-020` to create `mylifeindigital.content` and migrate publishable Markdown files out of the application repository.
+- Added `CR-021` to add `CONTENT_DIR` support to build and content-authoring tooling.
+- Added `CR-022` to update README, VS Code workspace, and local split-repository documentation.
+
 ## 2026-06-14
 
 ### Added
 
+- Added `CR-008` detail to define publishing lifecycle, readiness, trigger, failure, and rollback rules.
+- Added `CR-014` detail to define generated content artifact ownership, review, deployment, and rollback strategy.
 - Added `CR-019` to implement split-repository GitHub Actions CI/CD with a single application-owned production deployment workflow.
+- Added `CR-023` to establish a focused baseline test setup as a follow-up to the split-repository migration planning.
 
 ### Changed
 
+- Clarified `CR-019` so GitHub Actions are implemented in phases, with no-deploy validation working before production deployment is enabled.
 - Ingested the content authoring raw note into the docs wiki, clarifying the VS Code and Electron authoring boundaries.
 - Ingested the branching workflow raw note, recording branch-per-CR application work and short-lived content branches with draft safeguards.
 - Ingested the branch-protection update, documenting protected `main` branches and separate validation/deployment workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Repository-level changes for `mylifeindigital`. Web app release changes are tracked separately in `web/CHANGELOG.md`.
 
+## 2026-05-29
+
+### Added
+
+- Added `CR-018` to decide the future role of the web admin after the content repository split.
+- Added raw notes for content split local development and authoring-flow decisions.
+
+### Changed
+
+- Expanded `CR-007` with the post-split authoring path across VS Code, Electron, terminal, scripts, and browser admin.
+
 ## 2026-05-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Repository-level changes for `mylifeindigital`. Web app release changes are tracked separately in `web/CHANGELOG.md`.
 
+## 2026-06-14
+
+### Added
+
+- Added `CR-019` to implement split-repository GitHub Actions CI/CD with a single application-owned production deployment workflow.
+
+### Changed
+
+- Ingested the content authoring raw note into the docs wiki, clarifying the VS Code and Electron authoring boundaries.
+- Ingested the branching workflow raw note, recording branch-per-CR application work and short-lived content branches with draft safeguards.
+- Ingested the branch-protection update, documenting protected `main` branches and separate validation/deployment workflows.
+
 ## 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Repository-level changes for `mylifeindigital`. Web app release changes are tracked separately in `web/CHANGELOG.md`.
 
+## 2026-05-28
+
+### Changed
+
+- Ingested the content planning raw note into the docs wiki, including editor, content operations, open questions, index, and wiki log updates.
+- Ingested the Story Crafter raw note into the docs wiki as future feature memory, including a new project page and open questions.
+
 ## 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Repository-level changes for `mylifeindigital`. Web app release changes are trac
 ### Added
 
 - Added `CR-017` to track converting `docs/` into a Git-backed LLM wiki.
+- Added `CR-007` detail for deciding whether to keep one repository or split Markdown content into a separate content repository.
 - Added `docs/README.md`, `docs/WIKI.md`, and initial `docs/wiki/` pages for agent working memory.
 - Added a repo-local `llm-wiki` skill for ingesting, querying, and maintaining the docs wiki.
 - Added a repo-local `backlog-grooming` skill for maintaining change requests and indexing durable details into the docs wiki.

--- a/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
+++ b/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
@@ -109,6 +109,26 @@ The migration plan should decide whether `posts-data.ts` remains committed tempo
 
 Generated image assets and image manifests should be handled separately from publishable Markdown. They may be committed, uploaded to object storage such as R2, or regenerated depending on the existing image pipeline and the follow-up migration plan.
 
+### Local Development, Validation, And Deployment
+
+Local development should use two separate Git repositories in one VS Code workspace:
+
+- `mylifeindigital` for application code, build pipeline, docs, change requests, and experiments.
+- `mylifeindigital.content` for publishable Markdown content and content-owned assets.
+
+The application repository should support a configurable content path, likely `CONTENT_DIR`, so local builds can point at the sibling content checkout. Local content preview should mean editing Markdown in `mylifeindigital.content`, running the app build or dev command from `mylifeindigital/web`, generating `web/src/utils/posts-data.ts`, and rendering the selected content through the local Worker/dev server.
+
+CI validation should be split by repository trigger:
+
+- Application repository changes should install dependencies, typecheck/build the app, run relevant tests, build against the latest approved content commit or configured default content branch, and validate that `build-posts` can read the selected content repository commit.
+- Content repository changes should validate frontmatter/schema, run `build-posts` against the app pipeline, check drafts/excludes/images/metadata rules, and confirm `web/src/utils/posts-data.ts` can be generated without treating it as authored content.
+
+Image generation should not be required for every content validation run. OpenAI-backed image generation should be a separate explicit workflow or optional CI job so missing credits, invalid credentials, or provider availability do not block ordinary Markdown validation unless the content being published requires generated images.
+
+There are no preview deployments in the current workflow, and preview deployments are intentionally out of scope for the initial split because they add operational overhead. The initial workflow should rely on local preview, schema/build validation, and production deployment through GitHub Actions. Preview deployments should be reconsidered only if rendered review, branch-based app/content pairing, or pre-production visual validation becomes a recurring need.
+
+Production deployment should be orchestrated by GitHub Actions. The workflow should check out `mylifeindigital` from the selected application ref and `mylifeindigital.content` from the selected content ref, set `CONTENT_DIR`, run validation, generate `web/src/utils/posts-data.ts`, deploy with `wrangler deploy`, and log the application commit SHA and content commit SHA.
+
 The decision should account for:
 
 - how content changes are created, reviewed, synced, and published;
@@ -141,7 +161,7 @@ Before implementation begins, document the migration path, including content rep
 - [x] The decision keeps `change-requests/` in the application repository and explains that CRs remain branch-per-change planning artifacts tied closely to code and implementation work.
 - [x] The decision keeps `docs/` in the application repository and explains that docs/wiki notes remain code-adjacent working memory, can evolve with CR branches, and are not publishable content source.
 - [x] The decision defines `README.md` as the code repository's public profile and portfolio front door, not the canonical content index after the split.
-- [ ] The decision describes how local development, CI validation, deploy previews, and production deployment will work after the decision.
+- [x] The decision describes how local development, CI validation, deploy previews, and production deployment will work after the decision.
 - [ ] The decision identifies how browser admin, Electron/content operations, terminal, and script-based authoring flows are affected.
 - [ ] The decision preserves a practical VS Code workflow where website code and Markdown content can be visible in one workspace/solution view, even if they live in separate Git repositories.
 - [ ] The decision clarifies that VS Code remains the near-term Markdown editing tool until the Electron POC is mature enough for real content operations.

--- a/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
+++ b/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
@@ -129,6 +129,22 @@ There are no preview deployments in the current workflow, and preview deployment
 
 Production deployment should be orchestrated by GitHub Actions. The workflow should check out `mylifeindigital` from the selected application ref and `mylifeindigital.content` from the selected content ref, set `CONTENT_DIR`, run validation, generate `web/src/utils/posts-data.ts`, deploy with `wrangler deploy`, and log the application commit SHA and content commit SHA.
 
+Before GitHub Actions production deployment is enabled, `main` should be protected in both the application repository and the content repository. The baseline protection should require pull requests before merge, require relevant status checks, block force pushes, block branch deletion, and require conversation resolution where applicable. This supports the branch-per-CR workflow and prevents direct `main` pushes from bypassing validation or triggering accidental production deployment.
+
+### Authoring Flow Impact
+
+The split repository model makes local Git the primary authoring boundary for publishable content.
+
+The browser admin should no longer be treated as the primary long-term authoring surface for publishable content. If browser editing remains, it would need to write to the content repository through a remote API such as the GitHub API. That may be useful for lightweight edits or emergency changes, but it adds vendor-specific coupling and does not align as closely with the Git-first local workflow.
+
+The Electron content operations app is the preferred future content operations surface. It should operate on the local `mylifeindigital.content` checkout and use local Git, npm scripts, validation commands, content generation commands, preview/build commands, and narrow Git operations where practical. The app should focus on content creation and operations, not on editing the code used to build the editor.
+
+Terminal authoring should remain supported for power-user, Codex-assisted, maintenance, validation, and recovery workflows. The terminal should be able to run content creation, validation, build, and Git commands against the content repository and selected application pipeline without requiring the Electron app.
+
+Script-based authoring should continue, but scripts must stop assuming publishable Markdown lives inside the application repository. Scripts such as `scripts/new-content.ts` should target the content repository through a configurable content path, likely `CONTENT_DIR` or a related setting, so new content is written to `mylifeindigital.content` instead of the application repository's current Git branch.
+
+The authoring path after the split should be explicit: VS Code is the near-term Markdown editing tool, terminal and scripts remain supported operational paths, the Electron content operations app is the preferred future content operations surface, and browser admin is not the primary content authoring path. A separate follow-up request, `CR-018`, should decide whether the existing web admin is removed, made read-only, or retained for a narrow emergency/status role.
+
 The decision should account for:
 
 - how content changes are created, reviewed, synced, and published;
@@ -162,11 +178,12 @@ Before implementation begins, document the migration path, including content rep
 - [x] The decision keeps `docs/` in the application repository and explains that docs/wiki notes remain code-adjacent working memory, can evolve with CR branches, and are not publishable content source.
 - [x] The decision defines `README.md` as the code repository's public profile and portfolio front door, not the canonical content index after the split.
 - [x] The decision describes how local development, CI validation, deploy previews, and production deployment will work after the decision.
-- [ ] The decision identifies how browser admin, Electron/content operations, terminal, and script-based authoring flows are affected.
+- [x] The decision identifies how browser admin, Electron/content operations, terminal, and script-based authoring flows are affected.
 - [ ] The decision preserves a practical VS Code workflow where website code and Markdown content can be visible in one workspace/solution view, even if they live in separate Git repositories.
 - [ ] The decision clarifies that VS Code remains the near-term Markdown editing tool until the Electron POC is mature enough for real content operations.
 - [ ] The decision clarifies that the Electron POC should operate primarily on the content repository/workspace and should not require editing the app/editor implementation code during normal content creation.
 - [ ] The decision defines the minimum branch, pull request, or sync rules needed to keep authoring work from disrupting code work.
+- [ ] The migration plan includes protecting `main` in both the application repository and content repository before GitHub Actions production deployment is enabled.
 - [ ] The decision identifies dependencies or overlaps with `CR-008` publishing workflow rules.
 - [ ] If the split-repository model is chosen, a migration plan is documented before implementation, including repository ownership, folder structure, local checkout configuration, build integration, CI/deploy changes, and rollback path.
 - [ ] Follow-up implementation change requests are identified for any repository migration, workflow automation, CI changes, or documentation updates required by the decision.
@@ -175,8 +192,10 @@ Before implementation begins, document the migration path, including content rep
 ## Implementation Notes
 
 - Related source note: `docs/raw/90-day-plan.md`.
+- Related source note: `docs/raw/authoring-flows.md`.
 - Related wiki page: `docs/wiki/concepts/git-backed-content.md`.
 - Related workflow decision: `CR-008`, which is still a pending dashboard row until its detail file exists.
+- Follow-up request: `CR-018`, which should decide the future role of the web admin after the content repository split.
 - `CR-006` notes that repository-boundary and publishing workflow decisions overlap, but does not resolve this decision.
 - Previous wiki bias was to stay with a single Git repository while treating repository boundaries as an explicit design concern. This request now supersedes that bias by choosing a separate content repository as the next direction.
 

--- a/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
+++ b/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
@@ -1,0 +1,167 @@
+# CR-007: Decide Single Repo vs Split Content Repository
+
+Status: Proposed  
+Priority: High  
+Area: Architecture  
+Created: 2026-05-06
+
+## Context
+
+The project currently keeps website code, Markdown content, generated content artifacts, content operations scripts, and deployment configuration in one repository. This is simple, local-first, and aligned with the current Cloudflare Worker build model, where content is processed at build time and embedded into the Worker bundle.
+
+The repository is also becoming the center of multiple workflows: code development, Markdown authoring, admin/content operations, image generation, generated post data, validation, and publishing readiness. As content operations mature, the shared repository boundary may create more push/pull friction between writing work and code work.
+
+The 90-day planning notes identify this as an explicit architecture decision: either keep a single repository with stronger workflow rules, or split content and website code into separate repositories if authoring tools and publishing workflows need more isolation.
+
+From a practical authoring perspective, a split repository must not force the author into a separate editor context. The expected near-term workflow is to keep using VS Code for Markdown editing, with the code repository and a possible `mylifeindigital.content` repository/folder visible in one VS Code workspace. The future Electron POC should focus on content creation and operations, not on editing the code used to build the editor itself.
+
+## Goal
+
+Create a separate content repository for Markdown content so content authoring and website code development can have separate Git state.
+
+The chosen direction should preserve Markdown and Git as the source of truth, reduce avoidable workflow friction, and give future content operations work a clear repository boundary to design against.
+
+## Proposed Implementation
+
+Treat this request as a decision record and migration-planning item, not the repository migration itself.
+
+Decision: split publishable source Markdown content into a dedicated content repository, likely named `mylifeindigital.content`, while keeping website/runtime code in the existing application repository.
+
+The content repository should own publishable authored content and content-facing assets that belong to the writing workflow. The application repository should own the Hono/Cloudflare Worker app, build pipeline, deployment configuration, content processing code, generated runtime artifacts, change requests, docs/wiki knowledge, and code-adjacent notes.
+
+`change-requests/` should remain in the application repository because change requests operate on one Git branch per CR and usually relate closely to code, implementation planning, and repository workflow. `docs/` should also remain in the application repository because it is used for short notes, ideas, wiki-ingested project knowledge, architecture memory, and agent context that closely tracks the codebase. The repository README should remain the public profile and portfolio front door for the code repository, not the canonical content index.
+
+Change requests should continue to be managed from `change-requests/index.md`. When a CR moves from a dashboard idea into active decision work, planning, or implementation, a dedicated Git branch should be created for that CR. This keeps the CR document, implementation notes, and related code changes discardable as a unit if the direction is abandoned. Keeping in-progress CR work only on `main` would make rollback depend on commit-hash surgery instead of normal branch deletion or PR closure.
+
+Docs/wiki notes should remain code-adjacent working memory rather than becoming a third repository. If a raw note is added while a CR branch is in progress, that note can be understood in relation to the CR, code, and branch context where it was created. Splitting docs into another repository would add another VS Code workspace root and make that relationship harder to manage without providing a clear benefit for the current workflow.
+
+The boundary should be simple: publishable essays, posts, standalone pages, and public content move to `mylifeindigital.content`; raw notes, wiki pages, architecture memory, CR-adjacent thinking, and agent context remain in `mylifeindigital/docs`.
+
+After the split, `README.md` should describe the application repository's purpose, architecture, code experiments, docs/wiki workflow, and change-request workflow. It may link to the companion content repository and published site, but it should not try to maintain a full session log or publishable content catalog if that duplicates the content repository.
+
+### Rationale
+
+The project is still small enough that a split should stay lightweight. This does not need a CMS, database, or complex multi-repository platform. A separate content repository is justified because the workflow boundary is already visible: content creation can happen while unrelated code work is in progress, and `scripts/new-content.ts` currently writes publishable Markdown into whichever application branch is checked out.
+
+The main authoring friction is Git state collision. Writing a post, updating a standalone page, or generating content should not force the application repository's current feature branch to carry unrelated content changes. Separating publishable content into `mylifeindigital.content` lets content drafts, content commits, and content publishing history move independently from code implementation branches.
+
+Publishing confidence should improve because a content change can become an explicit deploy input rather than an incidental change inside a code branch. The site can still use build-time compiled content, but each deployment should be explainable as a combination of an application commit, a content commit, generated artifacts, and environment configuration.
+
+The split-repository deployment should be orchestrated by GitHub Actions rather than Cloudflare's native Git build trigger. GitHub Actions can check out both the application repository and the content repository, set the content source path for the build, run validation, generate runtime content artifacts, and deploy with `wrangler deploy`. This reduces dependence on Cloudflare's Git integration for build orchestration while keeping Cloudflare as the Worker runtime and deployment target.
+
+The content and code change rhythms are related but not identical. The code repository remains a showcase of thinking, code experiments, implementation planning, and docs/wiki knowledge. The content repository carries publishable writing that may be created, revised, and published on a different cadence from application changes.
+
+The operational overhead is acceptable only if the split preserves one practical authoring workspace. The near-term workflow should allow the application repository and content repository to be opened together in VS Code. The split should create separate Git ownership without requiring separate editor windows, heavyweight publishing tools, or a premature Electron dependency.
+
+### Canonical Content Source
+
+Publishable Markdown source should remain canonical in Git, specifically in the separate content repository. Git is the right source-of-truth mechanism for authored Markdown because it supports local-first editing, readable text diffs, commit messages, branches, review workflows, rollback, and a clear history of how writing changed over time.
+
+Object storage services may still be useful in the system, but they should not become the canonical Markdown authoring source. AWS S3-style versioning can preserve earlier object versions, and Cloudflare R2 can store durable objects for Workers-facing workflows, but object version history is not a replacement for Git's authoring model. Object storage is better suited to generated images, media assets, backups, generated artifacts, deploy support, or published asset delivery.
+
+The chosen split should therefore keep the authored Markdown files in Git and treat any object storage as supporting infrastructure, not as the primary content history.
+
+### Cloudflare Build Constraint
+
+Cloudflare Workers cannot read Markdown files from a repository filesystem at runtime. The current site works around that by running `web/scripts/build-posts.ts` before deployment and generating `web/src/utils/posts-data.ts`, which is bundled into the Worker.
+
+The current Cloudflare Worker build configuration is connected to the `mylifeindigital/mylifeindigital` Git repository. It uses `main` as the production branch, sets the build root directory to `/web`, runs `npm run build`, and deploys with `npx wrangler deploy`. Build watch paths currently include `*`, so changes in the connected application repository can trigger builds.
+
+Even though the build root is `/web`, the current build still depends on repository-level content because `web/scripts/build-posts.ts` reads Markdown from the application repository's `content/` directory and writes `web/src/utils/posts-data.ts`. The root-level content creation scripts are not the deploy entry point, but their output is consumed by the web build.
+
+The split repository model should keep that build-time compilation model for now. The change is that GitHub Actions, not Cloudflare's native Git build trigger, should assemble the build inputs. The deploy workflow should check out the application repository, check out the content repository, provide the content path to `build-posts.ts`, generate `posts-data.ts`, and then deploy the Worker with `wrangler deploy`.
+
+This means Cloudflare remains responsible for running the deployed Worker, routing traffic, and providing Worker environment bindings, but GitHub Actions owns the build orchestration. The project becomes less dependent on Cloudflare's dashboard-managed Git integration while still using Cloudflare as the runtime platform.
+
+The application should add a configurable content source path, such as `CONTENT_DIR`, so local development can point at a sibling `mylifeindigital.content` checkout and CI can point at the content repository checked out during the GitHub Actions workflow.
+
+Once GitHub Actions owns split-repository deployment, the Cloudflare native Git build trigger should be disabled or constrained so there is only one production deployment path. Otherwise app-repo pushes and content-repo pushes could produce deployments through different orchestration paths.
+
+### Deployment Inputs
+
+Each deployment should be traceable to a specific set of inputs:
+
+- Application commit: the `mylifeindigital` commit that provides the Hono/Cloudflare Worker code, build scripts, content processing pipeline, route definitions, package manifests, deployment configuration, and generated artifact policy.
+- Content commit: the `mylifeindigital.content` commit that provides the publishable Markdown source and content-owned assets used for that deployment.
+- Generated content artifacts: build outputs such as `web/src/utils/posts-data.ts` that are produced from the content commit during the deployment workflow and bundled into the Worker.
+- Environment configuration: GitHub Actions workflow variables and secrets, Wrangler/Cloudflare configuration, Worker environment variables, route bindings, and any service bindings such as R2 buckets.
+- Dependency lockfiles and runtime versions: npm lockfiles, Node.js version, Wrangler version, and other build-tool versions that affect the generated Worker bundle.
+
+GitHub Actions should log or expose the application commit SHA and content commit SHA for each deployment. The generated artifact does not need to become a separate source of truth, but the deployment workflow should make clear whether it is committed, ignored, uploaded as an artifact, or only generated inside CI before `wrangler deploy`.
+
+### Deployment Trigger Policy
+
+Content repository changes can trigger a web build and deployment even when no application code changed, because publishable Markdown is compiled into `web/src/utils/posts-data.ts` and bundled into the Worker.
+
+Application repository changes should not modify content. App changes may still trigger a web build and deployment when Worker code, build scripts, routing, schemas, dependencies, or deployment configuration changes. In that case the app deployment should build against a selected content commit rather than creating or changing content.
+
+The initial policy should be simple: production deployments use the latest `main` commit from the application repository and the latest `main` commit from the content repository. This keeps the GitHub Actions workflow straightforward while the split is new.
+
+The known risk is that an app-only deployment could include content changes that landed on content `main` since the previous deployment. If that becomes a problem, a later workflow can pin app-only deployments to the last deployed content SHA unless a content SHA is explicitly selected.
+
+### Generated Content Artifacts
+
+`web/src/utils/posts-data.ts` is a generated artifact produced by `web/scripts/build-posts.ts` from the selected content repository commit. It is required for the Worker bundle because the Worker cannot read Markdown files from a repository filesystem at runtime, but it is not the canonical content source.
+
+In the split-repository model, generated content artifacts should be produced during local builds and GitHub Actions deployments. Content review should focus on Markdown diffs, validation output, and rendered previews rather than treating `posts-data.ts` as hand-reviewed source.
+
+The migration plan should decide whether `posts-data.ts` remains committed temporarily for compatibility or becomes ignored and generated only during build/deploy. If it remains committed during the transition, generated diffs should be treated as verification output from the selected content commit rather than as authored content.
+
+Generated image assets and image manifests should be handled separately from publishable Markdown. They may be committed, uploaded to object storage such as R2, or regenerated depending on the existing image pipeline and the follow-up migration plan.
+
+The decision should account for:
+
+- how content changes are created, reviewed, synced, and published;
+- how the code and content repositories can be opened together in one VS Code workspace during the transition period;
+- how browser admin, desktop, terminal, or script-based authoring surfaces would write content;
+- how the existing build-time content pipeline would read content;
+- how generated artifacts such as `web/src/utils/posts-data.ts` would be produced and reviewed;
+- how `README.md`, `docs/`, and `change-requests/` should describe or support the split without moving away from the code repository;
+- how CI, deploy previews, and local development would work;
+- how much operational overhead is acceptable for a personal project.
+
+Before implementation begins, document the migration path, including content repository shape, local checkout expectations, VS Code workspace setup, build integration, CI/deploy behavior, and rollback considerations.
+
+## Acceptance Criteria
+
+- [x] The decision explicitly chooses one near-term repository model: split publishable Markdown content into a separate content repository.
+- [x] The decision explains the rationale in terms of current project scale, authoring friction, publishing confidence, content/code change rhythm, and operational overhead.
+- [x] Publishable Markdown files remain canonical in Git, rather than an object store, CMS, database, or generated artifact becoming the primary content source.
+- [x] The decision explains Git's practical advantages for authored Markdown: local-first editing, readable diffs, commit messages, branches, review workflows, rollback, and durable change history.
+- [x] The decision allows object storage for assets, backups, generated artifacts, deploy support, or published asset delivery, but not as the canonical Markdown authoring history.
+- [x] The decision accounts for the existing Cloudflare Worker deployment constraint that content is processed at build time rather than read from a runtime filesystem.
+- [x] The decision explicitly accepts, rejects, or time-boxes the current model where content publishing requires a web build because `web/src/utils/posts-data.ts` is generated from Markdown.
+- [x] If content remains build-time compiled, the decision defines how a content change triggers or participates in a web build and deployment.
+- [x] The decision chooses GitHub Actions as the split-repository build orchestrator and keeps Cloudflare as the Worker runtime and deployment target.
+- [x] The decision records the current Cloudflare build configuration: connected app repository, `/web` root directory, `npm run build`, `npx wrangler deploy`, production branch `main`, and broad build watch paths.
+- [x] The chosen model identifies the exact deployment inputs, including application commit, content commit, generated content artifacts, environment configuration, and dependency/runtime versions.
+- [x] The decision describes how the build-time content pipeline will access source Markdown in the chosen model.
+- [x] The decision defines that content repository changes can trigger web rebuilds, while application repository changes do not modify content and build against a selected content commit.
+- [x] The decision describes how generated content artifacts will be produced, reviewed, ignored, or committed in the chosen model.
+- [x] The decision keeps `change-requests/` in the application repository and explains that CRs remain branch-per-change planning artifacts tied closely to code and implementation work.
+- [x] The decision keeps `docs/` in the application repository and explains that docs/wiki notes remain code-adjacent working memory, can evolve with CR branches, and are not publishable content source.
+- [x] The decision defines `README.md` as the code repository's public profile and portfolio front door, not the canonical content index after the split.
+- [ ] The decision describes how local development, CI validation, deploy previews, and production deployment will work after the decision.
+- [ ] The decision identifies how browser admin, Electron/content operations, terminal, and script-based authoring flows are affected.
+- [ ] The decision preserves a practical VS Code workflow where website code and Markdown content can be visible in one workspace/solution view, even if they live in separate Git repositories.
+- [ ] The decision clarifies that VS Code remains the near-term Markdown editing tool until the Electron POC is mature enough for real content operations.
+- [ ] The decision clarifies that the Electron POC should operate primarily on the content repository/workspace and should not require editing the app/editor implementation code during normal content creation.
+- [ ] The decision defines the minimum branch, pull request, or sync rules needed to keep authoring work from disrupting code work.
+- [ ] The decision identifies dependencies or overlaps with `CR-008` publishing workflow rules.
+- [ ] If the split-repository model is chosen, a migration plan is documented before implementation, including repository ownership, folder structure, local checkout configuration, build integration, CI/deploy changes, and rollback path.
+- [ ] Follow-up implementation change requests are identified for any repository migration, workflow automation, CI changes, or documentation updates required by the decision.
+- [ ] The final decision is recorded in `Outcome` and reflected in the docs wiki if it becomes durable architecture knowledge.
+
+## Implementation Notes
+
+- Related source note: `docs/raw/90-day-plan.md`.
+- Related wiki page: `docs/wiki/concepts/git-backed-content.md`.
+- Related workflow decision: `CR-008`, which is still a pending dashboard row until its detail file exists.
+- `CR-006` notes that repository-boundary and publishing workflow decisions overlap, but does not resolve this decision.
+- Previous wiki bias was to stay with a single Git repository while treating repository boundaries as an explicit design concern. This request now supersedes that bias by choosing a separate content repository as the next direction.
+
+## Outcome
+
+Decision: create a separate content repository for publishable Markdown content, likely named `mylifeindigital.content`, while keeping website/runtime code, change requests, docs/wiki knowledge, and code-adjacent notes in the existing `mylifeindigital` application repository.
+
+The next step is to document the migration plan before moving files or changing the build pipeline.

--- a/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
+++ b/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
@@ -116,6 +116,17 @@ Local development should use two separate Git repositories in one VS Code worksp
 - `mylifeindigital` for application code, build pipeline, docs, change requests, and experiments.
 - `mylifeindigital.content` for publishable Markdown content and content-owned assets.
 
+The practical layout can keep both repositories as sibling folders and open them through a shared VS Code workspace file:
+
+```text
+projects/
+  mylifeindigital/
+  mylifeindigital.content/
+  mylifeindigital.code-workspace
+```
+
+VS Code can then show both folders in one workspace/solution view while preserving separate Git status, branch, commit, and pull-request state for each repository. Creating and documenting the actual `.code-workspace` file belongs to migration implementation rather than this decision request.
+
 The application repository should support a configurable content path, likely `CONTENT_DIR`, so local builds can point at the sibling content checkout. Local content preview should mean editing Markdown in `mylifeindigital.content`, running the app build or dev command from `mylifeindigital/web`, generating `web/src/utils/posts-data.ts`, and rendering the selected content through the local Worker/dev server.
 
 CI validation should be split by repository trigger:
@@ -144,6 +155,18 @@ Terminal authoring should remain supported for power-user, Codex-assisted, maint
 Script-based authoring should continue, but scripts must stop assuming publishable Markdown lives inside the application repository. Scripts such as `scripts/new-content.ts` should target the content repository through a configurable content path, likely `CONTENT_DIR` or a related setting, so new content is written to `mylifeindigital.content` instead of the application repository's current Git branch.
 
 The authoring path after the split should be explicit: VS Code is the near-term Markdown editing tool, terminal and scripts remain supported operational paths, the Electron content operations app is the preferred future content operations surface, and browser admin is not the primary content authoring path. A separate follow-up request, `CR-018`, should decide whether the existing web admin is removed, made read-only, or retained for a narrow emergency/status role.
+
+### Branch, Pull Request, And Sync Rules
+
+Application work should start from an up-to-date application `main` branch and use one short-lived branch per active CR. The CR document, implementation notes, code, tests, and related docs should remain together on that branch and merge through a pull request after relevant checks pass. If the CR is abandoned, its pull request can be closed and its branch deleted without rollback work on `main`.
+
+Content work should start from an up-to-date content `main` branch and use a short-lived branch for each new content item, revision, or small group of closely related content changes. New content should default to `draft: true`, be edited and validated on its content branch, and be previewed locally against the application pipeline. When publish-ready, the content should be changed to `draft: false`, merged through a pull request, and allowed to trigger the production build from content `main`.
+
+The `draft` flag is an additional publication safeguard, not a replacement for branch isolation. Unfinished or unrelated writing should not accumulate directly on content `main`.
+
+When an outcome requires coordinated application and content changes, use a CR branch in the application repository and a content branch in the content repository. Record the paired refs in the CR or pull-request descriptions, validate them together, and merge them in an order that keeps production compatible.
+
+Hosted environments for every branch are not required for the initial workflow. Local validation and CI checks are sufficient unless preview environments later provide enough recurring value to justify the operational overhead.
 
 The decision should account for:
 
@@ -179,11 +202,11 @@ Before implementation begins, document the migration path, including content rep
 - [x] The decision defines `README.md` as the code repository's public profile and portfolio front door, not the canonical content index after the split.
 - [x] The decision describes how local development, CI validation, deploy previews, and production deployment will work after the decision.
 - [x] The decision identifies how browser admin, Electron/content operations, terminal, and script-based authoring flows are affected.
-- [ ] The decision preserves a practical VS Code workflow where website code and Markdown content can be visible in one workspace/solution view, even if they live in separate Git repositories.
-- [ ] The decision clarifies that VS Code remains the near-term Markdown editing tool until the Electron POC is mature enough for real content operations.
-- [ ] The decision clarifies that the Electron POC should operate primarily on the content repository/workspace and should not require editing the app/editor implementation code during normal content creation.
-- [ ] The decision defines the minimum branch, pull request, or sync rules needed to keep authoring work from disrupting code work.
-- [ ] The migration plan includes protecting `main` in both the application repository and content repository before GitHub Actions production deployment is enabled.
+- [x] The decision preserves a practical VS Code workflow where website code and Markdown content can be visible in one workspace/solution view, even if they live in separate Git repositories.
+- [x] The decision clarifies that VS Code remains the near-term Markdown editing tool until the Electron POC is mature enough for real content operations.
+- [x] The decision clarifies that the Electron POC should operate primarily on the content repository/workspace and should not require editing the app/editor implementation code during normal content creation.
+- [x] The decision defines the minimum branch, pull request, or sync rules needed to keep authoring work from disrupting code work.
+- [x] The migration plan includes protecting `main` in both the application repository and content repository before GitHub Actions production deployment is enabled.
 - [ ] The decision identifies dependencies or overlaps with `CR-008` publishing workflow rules.
 - [ ] If the split-repository model is chosen, a migration plan is documented before implementation, including repository ownership, folder structure, local checkout configuration, build integration, CI/deploy changes, and rollback path.
 - [ ] Follow-up implementation change requests are identified for any repository migration, workflow automation, CI changes, or documentation updates required by the decision.
@@ -193,9 +216,12 @@ Before implementation begins, document the migration path, including content rep
 
 - Related source note: `docs/raw/90-day-plan.md`.
 - Related source note: `docs/raw/authoring-flows.md`.
+- Related source note: `docs/raw/branching-workflows.md`.
 - Related wiki page: `docs/wiki/concepts/git-backed-content.md`.
+- Related wiki page: `docs/wiki/decisions/branching-workflow.md`.
 - Related workflow decision: `CR-008`, which is still a pending dashboard row until its detail file exists.
 - Follow-up request: `CR-018`, which should decide the future role of the web admin after the content repository split.
+- Follow-up implementation: `CR-019`, which should implement split-repository GitHub Actions validation and deployment.
 - `CR-006` notes that repository-boundary and publishing workflow decisions overlap, but does not resolve this decision.
 - Previous wiki bias was to stay with a single Git repository while treating repository boundaries as an explicit design concern. This request now supersedes that bias by choosing a separate content repository as the next direction.
 

--- a/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
+++ b/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
@@ -207,10 +207,10 @@ Before implementation begins, document the migration path, including content rep
 - [x] The decision clarifies that the Electron POC should operate primarily on the content repository/workspace and should not require editing the app/editor implementation code during normal content creation.
 - [x] The decision defines the minimum branch, pull request, or sync rules needed to keep authoring work from disrupting code work.
 - [x] The migration plan includes protecting `main` in both the application repository and content repository before GitHub Actions production deployment is enabled.
-- [ ] The decision identifies dependencies or overlaps with `CR-008` publishing workflow rules.
-- [ ] If the split-repository model is chosen, a migration plan is documented before implementation, including repository ownership, folder structure, local checkout configuration, build integration, CI/deploy changes, and rollback path.
-- [ ] Follow-up implementation change requests are identified for any repository migration, workflow automation, CI changes, or documentation updates required by the decision.
-- [ ] The final decision is recorded in `Outcome` and reflected in the docs wiki if it becomes durable architecture knowledge.
+- [x] The decision identifies dependencies or overlaps with `CR-008` publishing workflow rules.
+- [x] If the split-repository model is chosen, a migration plan is documented before implementation, including repository ownership, folder structure, local checkout configuration, build integration, CI/deploy changes, and rollback path.
+- [x] Follow-up implementation change requests are identified for any repository migration, workflow automation, CI changes, or documentation updates required by the decision.
+- [x] The final decision is recorded in `Outcome` and reflected in the docs wiki if it becomes durable architecture knowledge.
 
 ## Implementation Notes
 
@@ -219,7 +219,7 @@ Before implementation begins, document the migration path, including content rep
 - Related source note: `docs/raw/branching-workflows.md`.
 - Related wiki page: `docs/wiki/concepts/git-backed-content.md`.
 - Related wiki page: `docs/wiki/decisions/branching-workflow.md`.
-- Related workflow decision: `CR-008`, which is still a pending dashboard row until its detail file exists.
+- Related workflow decision: `change-requests/CR-008-define-publishing-workflow-rules.md`.
 - Follow-up request: `CR-018`, which should decide the future role of the web admin after the content repository split.
 - Follow-up implementation: `CR-019`, which should implement split-repository GitHub Actions validation and deployment.
 - `CR-006` notes that repository-boundary and publishing workflow decisions overlap, but does not resolve this decision.
@@ -227,6 +227,8 @@ Before implementation begins, document the migration path, including content rep
 
 ## Outcome
 
-Decision: create a separate content repository for publishable Markdown content, likely named `mylifeindigital.content`, while keeping website/runtime code, change requests, docs/wiki knowledge, and code-adjacent notes in the existing `mylifeindigital` application repository.
+Decision: create a separate content repository for publishable Markdown content, likely named `mylifeindigital.content`, while keeping website/runtime code, build tooling, deployment configuration, generated runtime artifacts, change requests, docs/wiki knowledge, and code-adjacent notes in the existing `mylifeindigital` application repository.
 
-The next step is to document the migration plan before moving files or changing the build pipeline.
+The migration plan is documented in `docs/raw/repo-migration-notes.md`. The implementation work is split into follow-up CRs: `CR-020` for content repository creation and file migration, `CR-021` for `CONTENT_DIR` tooling, `CR-022` for README/workspace/local docs, `CR-019` for GitHub Actions CI/CD, `CR-014` for generated artifacts, `CR-018` for the web admin role, and `CR-023` for baseline test setup.
+
+The durable architecture knowledge is reflected in the docs wiki, especially `docs/wiki/concepts/git-backed-content.md` and `docs/wiki/decisions/branching-workflow.md`.

--- a/change-requests/CR-008-define-publishing-workflow-rules.md
+++ b/change-requests/CR-008-define-publishing-workflow-rules.md
@@ -1,0 +1,133 @@
+# CR-008: Define Publishing Workflow Rules
+
+Status: Proposed  
+Priority: High  
+Area: Publishing  
+Created: 2026-05-06
+
+## Context
+
+Publishable Markdown content will move to a separate Git repository, likely `mylifeindigital.content`, while the Hono/Cloudflare Worker application, content processing pipeline, and deployment configuration remain in `mylifeindigital`.
+
+The Worker cannot read Markdown from a repository filesystem at runtime. Publishing therefore requires a build that combines an application commit and content commit, runs `web/scripts/build-posts.ts`, generates `web/src/utils/posts-data.ts`, and deploys the resulting Worker bundle.
+
+`CR-007` defines the repository boundary and establishes GitHub Actions as the future build orchestrator. `CR-019` owns implementation of the cross-repository CI/CD workflows. This request defines the publishing rules those workflows must enforce.
+
+## Goal
+
+Define a predictable publishing workflow for creating, validating, approving, deploying, and rolling back content without coupling ordinary writing work to application-code branches.
+
+The workflow should preserve Markdown and Git as the source of truth, keep incomplete content away from production, and make every production deployment traceable to an application commit and content commit.
+
+## Proposed Implementation
+
+### Content Lifecycle
+
+Use the following publishing lifecycle:
+
+1. Start from an up-to-date content `main` branch.
+2. Create a short-lived branch for a new content item, revision, or small group of closely related changes.
+3. Generate new content with `draft: true`.
+4. Edit and validate the Markdown on the content branch.
+5. Preview the content locally against the selected application pipeline.
+6. Resolve publication blockers and set `draft: false` when the content is publish-ready.
+7. Open a pull request and require the relevant content validation checks.
+8. Merge the content pull request into protected content `main`.
+9. Request the application repository's production deployment workflow.
+10. Build and deploy the combined application/content Worker artifact.
+
+The `draft` flag is a publication safeguard, not a replacement for branch isolation or validation.
+
+### Publish-Readiness Rules
+
+A content item is publish-ready when:
+
+- required frontmatter and content-type metadata are valid;
+- `draft` is `false`;
+- Markdown processing completes without blocking errors;
+- unresolved AI assistance markers do not remain;
+- required assets are available;
+- content validation and application compatibility checks pass;
+- the content change has been reviewed through its pull request, even when no second-person approval is required.
+
+Warnings that do not affect correctness may remain non-blocking, but the validation system should distinguish warnings from publication blockers.
+
+OpenAI-backed image generation should not run as part of every validation pass. It should be an explicit or optional workflow and should block publication only when the content requires a generated image that is missing or invalid.
+
+### Deployment Trigger Rules
+
+- Pull requests run validation only and never deploy production.
+- Merging content `main` requests a production deployment because content must be compiled into the Worker bundle.
+- Merging application `main` may trigger production deployment when runtime code, build scripts, schemas, dependencies, routes, or deployment configuration change.
+- The application repository owns the only workflow that performs `wrangler deploy`.
+- The content repository validates content and requests deployment; it does not deploy Cloudflare directly.
+- Production deployment initially uses the latest trusted application `main` and content `main` commits.
+- Manual deployment may select explicit application and content refs for recovery or controlled redeployment.
+
+There are no hosted preview deployments in the initial workflow. Local preview and build-only pull-request validation are sufficient until recurring review needs justify the additional operational overhead.
+
+### Approval And Branch Rules
+
+- Protect `main` in both repositories before automated production deployment is enabled.
+- Require pull requests and relevant status checks before merge.
+- Block force pushes and branch deletion.
+- Require review conversations to be resolved.
+- Do not require approval from another person initially because this is a single-author project.
+- Allow administrative bypass only for recovery, not routine publishing.
+
+### Deployment Success And Failure
+
+A content merge and a successful production deployment are separate events. If deployment fails after content reaches `main`:
+
+- keep the failed workflow visible with its application/content refs;
+- do not create follow-up commits solely to retrigger an unchanged deployment;
+- fix the underlying issue or manually redeploy the selected refs;
+- confirm the deployed Worker before treating the publication as complete.
+
+Only one production workflow should deploy at a time. Competing application/content events should be serialized or superseded through workflow concurrency rules.
+
+### Rollback
+
+Rollback should redeploy a known-good application SHA and content SHA through the application repository workflow.
+
+If the source content itself must be corrected or withdrawn, make that change through a new content branch and pull request so Git history remains explicit. Do not treat generated `posts-data.ts` as the rollback source.
+
+### Scope Boundaries
+
+- `CR-007` owns the repository-boundary and architecture decision.
+- `CR-008` owns publishing lifecycle, readiness, trigger, approval, failure, and rollback rules.
+- `CR-013` owns detailed content validation checks.
+- `CR-014` owns the generated content artifact strategy.
+- `CR-019` implements the GitHub Actions workflows that enforce these rules.
+
+## Acceptance Criteria
+
+- [ ] The content lifecycle from branch creation through confirmed production deployment is documented.
+- [ ] Publish-readiness rules distinguish blocking errors from non-blocking warnings.
+- [ ] New content defaults to `draft: true`, and `draft: false` is required before publication.
+- [ ] The workflow requires content branches and pull requests rather than using draft status as the only isolation mechanism.
+- [ ] Pull requests run validation without production deployment.
+- [ ] Content `main` merges request production deployment through the application repository.
+- [ ] Application `main` deployment triggers are defined.
+- [ ] The application repository is the only owner of `wrangler deploy`.
+- [ ] Initial application/content ref selection rules are documented.
+- [ ] Manual deployment with explicit application and content refs is supported for recovery.
+- [ ] Branch protection and solo-author approval rules are documented.
+- [ ] Image generation behavior distinguishes ordinary validation from required publication assets.
+- [ ] Failed deployment behavior distinguishes a merged content change from a completed publication.
+- [ ] Rollback uses explicit known-good application and content SHAs.
+- [ ] Hosted preview deployments are explicitly out of scope for the initial workflow.
+- [ ] Dependencies and ownership boundaries with `CR-007`, `CR-013`, `CR-014`, and `CR-019` are explicit.
+
+## Implementation Notes
+
+- Related architecture decision: `change-requests/CR-007-decide-single-repo-vs-split-content-repository.md`.
+- CI/CD implementation: `change-requests/CR-019-implement-split-repository-github-actions-ci-cd.md`.
+- Content validation remains a separate concern under `CR-013`.
+- Generated artifact ownership remains a separate concern under `CR-014`.
+- Related wiki decision: `docs/wiki/decisions/branching-workflow.md`.
+- Related source note: `docs/raw/content-split.md`.
+
+## Outcome
+
+Pending decision.

--- a/change-requests/CR-014-reassess-generated-content-artifact-strategy.md
+++ b/change-requests/CR-014-reassess-generated-content-artifact-strategy.md
@@ -1,0 +1,59 @@
+# CR-014: Reassess Generated Content Artifact Strategy
+
+Status: Proposed  
+Priority: Medium  
+Area: Architecture  
+Created: 2026-05-06
+
+## Context
+
+The current web app compiles Markdown content into `web/src/utils/posts-data.ts` at build time because Cloudflare Workers cannot read Markdown files from a repository filesystem at runtime. That generated file is ignored by Git and should not be edited manually.
+
+`CR-007` chooses a split-repository model where publishable Markdown moves to `mylifeindigital.content`, while the application, build scripts, deployment configuration, change requests, and docs remain in `mylifeindigital`. In that model, generated artifacts become an important boundary: Markdown remains canonical, but deployment still requires generated content outputs.
+
+The current image-generation pipeline also has generated state. Existing generated images are stored remotely in Cloudflare/R2 and referenced through generated metadata. The current `web/scripts/image-manifest.json` remains app-owned during the initial split because it is coupled to the current image-generation scripts.
+
+## Goal
+
+Define the strategy for generated content artifacts after the repository split, including which artifacts are generated-only, which are committed, which are uploaded to object storage, and how they are reviewed, ignored, traced, and used during deployment or rollback.
+
+## Proposed Implementation
+
+Document and implement a generated-artifact policy that covers:
+
+- `web/src/utils/posts-data.ts` as a generated-only build artifact, not canonical content.
+- Generated image assets and image manifest state.
+- Whether `web/scripts/image-manifest.json` remains app-owned, moves to the content repository, or becomes CI/object-storage managed.
+- Which generated artifacts should be ignored by Git.
+- Which generated artifacts, if any, should be committed for review or rollback.
+- How GitHub Actions should produce generated artifacts during app/content deployment.
+- How local development should generate and inspect artifacts without treating them as authored content.
+- How rollback should use known-good application/content SHAs rather than treating generated files as the rollback source.
+
+The first likely decision is to keep `posts-data.ts` generated-only and ignored, with GitHub Actions generating it during deployment after checking out the selected application commit and content commit. Generated image ownership can be decided separately inside this request because it has different storage and reproducibility concerns.
+
+## Acceptance Criteria
+
+- [ ] The generated-artifact policy states that Markdown in Git remains the canonical publishable content source.
+- [ ] The policy states whether `web/src/utils/posts-data.ts` is committed, ignored, uploaded as a CI artifact, or generated only inside local/CI builds.
+- [ ] The policy defines how `posts-data.ts` is produced during local development, CI validation, and production deployment.
+- [ ] The policy defines how generated artifacts are reviewed without treating generated output as authored content.
+- [ ] The policy defines how generated artifacts relate to rollback and deployment traceability.
+- [ ] The policy decides where `web/scripts/image-manifest.json` should live after the split, or explicitly time-boxes that decision.
+- [ ] The policy decides how generated images and remote object-storage assets are owned, validated, and regenerated.
+- [ ] Git ignore rules, build scripts, and CI expectations are updated to match the chosen artifact strategy.
+- [ ] Documentation explains the boundary between authored Markdown, generated TypeScript data, generated image metadata, and deployed Worker artifacts.
+
+## Implementation Notes
+
+- Depends on the repository boundary decision in `CR-007`.
+- Aligns with publishing workflow rules in `CR-008`.
+- Overlaps with content validation in `CR-013`; this request should define artifact ownership while `CR-013` defines validation behavior.
+- Informs GitHub Actions deployment implementation in `CR-019`.
+- Related migration note: `docs/raw/repo-migration-notes.md`.
+- Current known position from migration planning: `posts-data.ts` should remain generated-only after the split; GitHub Actions should generate it in the workflow workspace and deploy the resulting Worker bundle.
+- Current known position from migration planning: generated images are remote in Cloudflare/R2, and `web/scripts/image-manifest.json` remains app-owned during the initial cutover.
+
+## Outcome
+
+Pending implementation.

--- a/change-requests/CR-018-decide-web-admin-role-after-content-repository-split.md
+++ b/change-requests/CR-018-decide-web-admin-role-after-content-repository-split.md
@@ -1,0 +1,54 @@
+# CR-018: Decide Web Admin Role After Content Repository Split
+
+Status: Proposed  
+Priority: Medium  
+Area: Web Admin  
+Created: 2026-05-29
+
+## Context
+
+`CR-007` chooses a split repository model where publishable Markdown content moves to a dedicated content repository, likely `mylifeindigital.content`, while the application repository keeps the Hono/Cloudflare Worker app, build pipeline, docs, change requests, and code-adjacent notes.
+
+That decision changes the authoring model. VS Code remains the near-term Markdown editor, terminal/scripts remain supported operational paths, and the Electron content operations app is the preferred future content operations surface because it can operate on a local Git checkout and run local npm/Git workflows.
+
+The existing web admin was built for the current repository shape. If it is not updated for the split content repository, keeping it as a write-capable content editor could create confusion, security risk, and maintenance overhead. Browser-based editing would likely need to write to the content repository through a remote API such as the GitHub API, which is less aligned with the Git-first local workflow and introduces vendor-specific coupling.
+
+## Goal
+
+Decide the future role of the existing web admin after the content repository split.
+
+The decision should choose whether to remove the web admin, disable write-capable content editing, convert it to read-only/status/admin inspection, or retain a narrow emergency editing role.
+
+## Proposed Implementation
+
+Treat this request as a focused decision and cleanup plan for the web admin surface.
+
+Evaluate these options:
+
+- Remove the existing web admin content editing surface if it no longer has a clear role.
+- Keep the web admin but make content-related views read-only.
+- Keep only non-content administrative/status functionality that remains useful for the deployed web app.
+- Retain a narrow emergency content-editing path through the GitHub API only if the operational value clearly outweighs the security, maintenance, and vendor-coupling costs.
+
+The preferred default is to avoid keeping an ambiguous write-capable browser admin for publishable content. The primary authoring path should be VS Code now, Electron later, and terminal/scripts throughout.
+
+## Acceptance Criteria
+
+- [ ] The decision explicitly chooses the future role of the web admin after the content repository split.
+- [ ] The decision states whether browser-based content editing is removed, disabled, made read-only, or retained for a narrow emergency role.
+- [ ] The decision explains how the chosen role aligns with the Git-first content repository model.
+- [ ] The decision identifies any security, authentication, GitHub API, or vendor-coupling implications.
+- [ ] The decision identifies which existing web admin routes, APIs, services, or UI views should be removed, retained, or changed.
+- [ ] The decision explains how the choice affects VS Code, Electron, terminal, and script-based authoring paths.
+- [ ] Follow-up implementation work is identified if web admin routes, services, tests, docs, or README content need updates.
+
+## Implementation Notes
+
+- Related repository-boundary decision: `change-requests/CR-007-decide-single-repo-vs-split-content-repository.md`.
+- Related source note: `docs/raw/authoring-flows.md`.
+- Existing admin routes live under `web/src/routes/admin/`.
+- Current content editing uses GitHub API services under `web/src/services/content/`.
+
+## Outcome
+
+Pending decision.

--- a/change-requests/CR-019-implement-split-repository-github-actions-ci-cd.md
+++ b/change-requests/CR-019-implement-split-repository-github-actions-ci-cd.md
@@ -1,0 +1,107 @@
+# CR-019: Implement Split-Repository GitHub Actions CI/CD
+
+Status: Proposed  
+Priority: High  
+Area: Deployment  
+Created: 2026-06-14
+
+## Context
+
+`CR-007` chooses a separate Git repository for publishable Markdown content while keeping the Hono/Cloudflare Worker application, build pipeline, deployment configuration, change requests, and docs/wiki knowledge in `mylifeindigital`.
+
+The deployed Worker remains a combined artifact. GitHub Actions must assemble a selected application commit and content commit, run `web/scripts/build-posts.ts`, generate `web/src/utils/posts-data.ts`, build the application, and deploy with Wrangler.
+
+Cloudflare currently owns Git-triggered build and deployment from the application repository. The split-repository model instead requires one CI/CD orchestrator that can react to trusted changes in either repository without creating duplicate production deployment paths.
+
+## Goal
+
+Implement GitHub Actions validation and production deployment for the split application/content repository model.
+
+The application repository should own the only production deployment workflow. The content repository should own content-specific validation and request a deployment from the application repository when publishable content reaches content `main`.
+
+## Proposed Implementation
+
+### Application Repository Workflows
+
+Add workflows under `mylifeindigital/.github/workflows/`:
+
+- `app-ci.yml` for pull-request validation without deployment.
+- `deploy.yml` as the single production deployment owner.
+
+`app-ci.yml` should install locked dependencies, run relevant tests and type checks, check out the selected/default content ref, generate content artifacts, and prove that the Worker can build without deploying it.
+
+`deploy.yml` should support:
+
+- trusted application `main` merges;
+- trusted dispatches from the content repository after content reaches content `main`;
+- manual dispatch with explicit application and content refs for recovery or controlled redeployment.
+
+The deploy workflow should:
+
+1. Resolve and check out the selected application commit.
+2. Check out the selected `mylifeindigital.content` commit.
+3. Configure `CONTENT_DIR`.
+4. Install dependencies from lockfiles.
+5. Run required validation, tests, and type checks.
+6. Generate `web/src/utils/posts-data.ts`.
+7. Build and deploy with `wrangler deploy`.
+8. Record the resolved application SHA and content SHA in the workflow summary.
+
+### Content Repository Workflows
+
+Add workflows under `mylifeindigital.content/.github/workflows/`:
+
+- `content-ci.yml` for pull-request validation without deployment.
+- `request-deploy.yml` to dispatch the application repository's production workflow after a trusted content `main` merge.
+
+The content validation workflow should check frontmatter/schema rules, drafts, excludes, metadata, and compatibility with the selected application pipeline. OpenAI-backed image generation should remain separate or optional so ordinary validation does not depend on provider credits or credentials unless generated images are required for publication.
+
+The content repository must not run `wrangler deploy` directly.
+
+### Security And Operational Rules
+
+- Store Cloudflare credentials in GitHub Actions secrets or a protected GitHub environment.
+- Decide the credential mechanism for cross-repository checkout and dispatch. Public repositories may need no extra checkout credential; private cross-repository access requires a narrowly scoped GitHub App token or equivalent credential.
+- Grant the least GitHub Actions permissions needed by each workflow.
+- Use production concurrency controls so competing app/content events cannot deploy simultaneously.
+- Protect `main` in both repositories and require the relevant CI checks before merge.
+- Pull-request workflows must not receive production deployment credentials or deploy.
+- Disable or constrain Cloudflare's native Git build trigger only after the GitHub Actions deployment path has been validated.
+
+### Rollback And Traceability
+
+The workflow should support redeploying an explicit application SHA with an explicit content SHA. Workflow summaries and deployment records should identify both resolved commits and the environment/configuration used for the deployment.
+
+Generated `posts-data.ts` remains a build artifact rather than canonical content. Its committed/ignored transition should follow the generated-artifact decision in `CR-007` and any implementation detail owned by `CR-014`.
+
+## Acceptance Criteria
+
+- [ ] Application pull requests run build-only CI and never deploy.
+- [ ] Content pull requests run content validation and never deploy.
+- [ ] The application repository contains the only workflow that runs `wrangler deploy`.
+- [ ] A trusted application `main` merge can trigger production deployment with a selected content commit.
+- [ ] A trusted content `main` merge can request production deployment through the application repository workflow.
+- [ ] Manual deployment supports explicit application and content refs for recovery or controlled redeployment.
+- [ ] The deployment workflow checks out both repositories and passes a configured content path to `web/scripts/build-posts.ts`.
+- [ ] The deployment workflow validates, generates `web/src/utils/posts-data.ts`, builds, and deploys the combined Worker artifact.
+- [ ] Every deployment records the resolved application SHA and content SHA.
+- [ ] Cross-repository checkout and dispatch credentials are documented and use least privilege.
+- [ ] Cloudflare credentials are stored as protected secrets and are unavailable to untrusted pull-request workflows.
+- [ ] Production deployment uses concurrency protection to prevent competing deployments.
+- [ ] Required CI checks are compatible with branch protection in both repositories.
+- [ ] OpenAI-backed image generation is optional/separate unless publication explicitly requires generated images.
+- [ ] Cloudflare's native Git deployment path is disabled or constrained after GitHub Actions deployment is verified.
+- [ ] Documentation explains normal deployment, manual redeployment, failure handling, and rollback using explicit refs.
+
+## Implementation Notes
+
+- Depends on the repository and deployment decisions in `change-requests/CR-007-decide-single-repo-vs-split-content-repository.md`.
+- Publishing trigger and approval rules should align with `CR-008`.
+- Content validation rules overlap with `CR-013`; this request should orchestrate those checks rather than redefine their domain behavior.
+- Generated artifact ownership overlaps with `CR-014`.
+- Production workflow ownership belongs to the application repository because it owns `web/wrangler.toml`, Worker source, build tooling, and Cloudflare deployment configuration.
+- Related wiki decision: `docs/wiki/decisions/branching-workflow.md`.
+
+## Outcome
+
+Pending implementation.

--- a/change-requests/CR-019-implement-split-repository-github-actions-ci-cd.md
+++ b/change-requests/CR-019-implement-split-repository-github-actions-ci-cd.md
@@ -21,6 +21,19 @@ The application repository should own the only production deployment workflow. T
 
 ## Proposed Implementation
 
+### Phased Implementation
+
+Implement GitHub Actions in phases so the split-repository build path is proven before production deployment changes.
+
+1. Add no-deploy application CI in `mylifeindigital`.
+   This workflow should run on application pull requests, check out the application repository plus a selected/default content repository ref, configure `CONTENT_DIR`, generate `web/src/utils/posts-data.ts`, and run the web build/typecheck without deploying.
+2. Add no-deploy content CI in `mylifeindigital.content`.
+   This workflow should run on content pull requests and validate that Markdown content can be processed by the application build pipeline without deploying.
+3. Add production deployment in `mylifeindigital`.
+   This workflow should be added only after the no-deploy CI path is working and should be the only workflow that runs `wrangler deploy`.
+
+Tests should be included when they exist, but the initial migration CI does not need to wait for a full test suite. The minimum useful protection is proving dependency install, cross-repository checkout, `CONTENT_DIR`, `web/scripts/build-posts.ts`, generated `web/src/utils/posts-data.ts`, and the web build/typecheck before deployment is enabled.
+
 ### Application Repository Workflows
 
 Add workflows under `mylifeindigital/.github/workflows/`:
@@ -76,6 +89,7 @@ Generated `posts-data.ts` remains a build artifact rather than canonical content
 
 ## Acceptance Criteria
 
+- [ ] GitHub Actions implementation is phased so no-deploy validation is working before production deployment is enabled.
 - [ ] Application pull requests run build-only CI and never deploy.
 - [ ] Content pull requests run content validation and never deploy.
 - [ ] The application repository contains the only workflow that runs `wrangler deploy`.
@@ -100,6 +114,7 @@ Generated `posts-data.ts` remains a build artifact rather than canonical content
 - Content validation rules overlap with `CR-013`; this request should orchestrate those checks rather than redefine their domain behavior.
 - Generated artifact ownership overlaps with `CR-014`.
 - Production workflow ownership belongs to the application repository because it owns `web/wrangler.toml`, Worker source, build tooling, and Cloudflare deployment configuration.
+- Migration phasing is informed by `docs/raw/repo-migration-notes.md`, especially the decision to prove no-deploy CI before enabling the production deploy workflow.
 - Related wiki decision: `docs/wiki/decisions/branching-workflow.md`.
 
 ## Outcome

--- a/change-requests/CR-020-create-content-repository-and-migrate-files.md
+++ b/change-requests/CR-020-create-content-repository-and-migrate-files.md
@@ -1,0 +1,80 @@
+# CR-020: Create Content Repository And Migrate Files
+
+Status: Proposed  
+Priority: High  
+Area: Architecture  
+Created: 2026-06-16
+
+## Context
+
+`CR-007` chooses a split-repository model where publishable Markdown content moves out of the application repository and into a dedicated content repository, likely named `mylifeindigital.content`.
+
+The current application repository still contains publishable Markdown under `content/`. This means content authoring and application-code work share the same Git branch, which can mix unrelated content and code changes. The split should create separate Git state for publishable content while preserving a practical local workflow.
+
+## Goal
+
+Create the `mylifeindigital.content` repository and migrate the publishable Markdown source tree into it, leaving the application repository with only a placeholder `content/` directory.
+
+## Proposed Implementation
+
+Create a new local repository/folder named `mylifeindigital.content`, then create the matching GitHub repository and push the initial content history.
+
+The content repository should use this initial structure:
+
+- `content/index.md`
+- `content/pages/`
+- `content/posts/`
+- `content/technical-sessions/`
+- `.gitignore`
+- `README.md`
+
+Move only the publishable content source tree:
+
+- `content/index.md`
+- `content/pages/`
+- `content/posts/`
+- `content/technical-sessions/`
+
+Do not move:
+
+- `web/public/`
+- `docs/`
+- `change-requests/`
+- app source
+- build scripts
+- generated runtime artifacts
+- `web/scripts/image-manifest.json`
+
+After migration, replace `mylifeindigital/content/` in the application repository with a README placeholder. The placeholder should explain that publishable content now lives in `mylifeindigital.content/content/`, local builds should use `CONTENT_DIR`, and the application repository no longer owns publishable Markdown source files.
+
+Protect `main` in both repositories before automated GitHub Actions production deployment is enabled.
+
+## Acceptance Criteria
+
+- [ ] A local `mylifeindigital.content` repository exists.
+- [ ] A GitHub repository exists for `mylifeindigital.content`.
+- [ ] Publishable Markdown is migrated to `mylifeindigital.content/content/`.
+- [ ] `content/index.md`, `content/pages/`, `content/posts/`, and `content/technical-sessions/` are present in the content repository.
+- [ ] Technical sessions are migrated because they are rendered publishable content.
+- [ ] Non-content application files, docs, change requests, build scripts, generated artifacts, and image manifest state remain in `mylifeindigital`.
+- [ ] The application repository `content/` directory contains only a README placeholder after cutover.
+- [ ] The content repository includes a minimal `.gitignore`.
+- [ ] The content repository includes a README that explains its purpose, folder structure, and relationship to the application repository.
+- [ ] `main` branch protection expectations are documented for both repositories before automated production deployment is enabled.
+- [ ] The migration does not require GitHub Actions production deployment to be enabled in the same change.
+
+## Implementation Notes
+
+- Depends on the repository decision in `CR-007`.
+- `CR-021` should add `CONTENT_DIR` support to `web/scripts/build-posts.ts` and root content scripts.
+- `CR-022` should update README, VS Code workspace, and local development documentation.
+- `CR-019` owns split-repository GitHub Actions CI/CD.
+- `CR-014` owns generated content artifact strategy.
+- `CR-018` owns the future role of the web admin after the content split.
+- Current migration notes live in `docs/raw/repo-migration-notes.md`.
+- Existing generated images are remote in Cloudflare/R2; `web/scripts/image-manifest.json` remains app-owned during the initial cutover.
+- `content/technical-sessions/` moves because it is rendered by the web app as publishable content.
+
+## Outcome
+
+Pending implementation.

--- a/change-requests/CR-021-add-content-dir-support-to-content-tooling.md
+++ b/change-requests/CR-021-add-content-dir-support-to-content-tooling.md
@@ -1,0 +1,69 @@
+# CR-021: Add CONTENT_DIR Support To Content Tooling
+
+Status: Proposed  
+Priority: High  
+Area: Content Pipeline  
+Created: 2026-06-16
+
+## Context
+
+`CR-007` chooses a split-repository model where publishable Markdown moves to `mylifeindigital.content` while the application repository keeps the Hono/Cloudflare Worker app, build scripts, deployment configuration, docs, and change requests.
+
+After the split, content tooling can no longer assume that publishable Markdown lives in the application repository's `content/` directory. The current build pipeline and content creation scripts need a shared way to locate the content repository checkout.
+
+The migration notes define `CONTENT_DIR` as the shared convention:
+
+```text
+CONTENT_DIR=../mylifeindigital.content/content
+```
+
+The root `.env` file should be the canonical local content-tooling configuration because both root scripts and web build scripts need the same content path.
+
+## Goal
+
+Update content build and authoring tooling so it can read from or write to a configurable content source path through `CONTENT_DIR`, allowing the application repository and content repository to work as separate Git repositories.
+
+## Proposed Implementation
+
+Add shared `CONTENT_DIR` support for:
+
+- `web/scripts/build-posts.ts`
+- root content creation scripts such as `scripts/new-content.ts`
+- any related local tooling that currently assumes publishable Markdown lives at `mylifeindigital/content/`
+
+Tools should resolve the content directory in this order:
+
+1. Use `CONTENT_DIR` from the process environment when set.
+2. Load `CONTENT_DIR` from the root `.env` for local tooling.
+3. During migration only, fall back to the application repository `content/` path.
+4. After the split is stable, remove the fallback and require `CONTENT_DIR` for split-repository builds and content creation.
+
+`web/.env` may still be used for web-specific build configuration, but it should not become a second competing source for the content repository path unless a later decision explicitly changes that.
+
+`scripts/new-content.ts` should write new publishable Markdown to the configured content repository path, not to the application repository's current branch.
+
+## Acceptance Criteria
+
+- [ ] `web/scripts/build-posts.ts` can read publishable Markdown from `CONTENT_DIR`.
+- [ ] Root content creation scripts can write new publishable Markdown to `CONTENT_DIR`.
+- [ ] Local tooling can load `CONTENT_DIR` from the process environment or root `.env`.
+- [ ] The transitional fallback to the application repository `content/` path is explicit and documented.
+- [ ] The implementation identifies when the fallback should be removed after the split stabilizes.
+- [ ] Missing or invalid `CONTENT_DIR` produces a clear actionable error when fallback is disabled or unavailable.
+- [ ] The implementation avoids treating `web/.env` as a competing source for the content repository path.
+- [ ] Local build and content-creation commands are verified against a sibling content checkout or a documented test path.
+- [ ] Generated `web/src/utils/posts-data.ts` remains generated-only and is not edited manually.
+
+## Implementation Notes
+
+- Depends on the repository decision in `CR-007`.
+- Coordinates with `CR-020`, which creates `mylifeindigital.content` and migrates publishable Markdown files.
+- Coordinates with `CR-019`, which will pass `CONTENT_DIR` in GitHub Actions workflows.
+- Coordinates with `CR-022`, which should document the local workspace and command usage.
+- Generated artifact policy remains owned by `CR-014`.
+- Initial local convention from migration planning: `CONTENT_DIR=../mylifeindigital.content/content`.
+- Root `.env` is the preferred local configuration source because both root scripts and web build scripts need the same content repository path.
+
+## Outcome
+
+Pending implementation.

--- a/change-requests/CR-022-update-readme-workspace-and-local-docs.md
+++ b/change-requests/CR-022-update-readme-workspace-and-local-docs.md
@@ -1,0 +1,64 @@
+# CR-022: Update README, Workspace, And Local Docs
+
+Status: Proposed  
+Priority: Medium  
+Area: Documentation  
+Created: 2026-06-16
+
+## Context
+
+`CR-007` chooses a split-repository model where publishable Markdown moves to `mylifeindigital.content`, while application code, build tooling, docs, change requests, and code-adjacent notes remain in `mylifeindigital`.
+
+The split should preserve a practical VS Code workflow where the application repository and content repository are visible in one workspace. It should also clarify the purpose of the application repository README, which currently has profile/marketing and repository-structure concerns mixed with content/session references.
+
+## Goal
+
+Update repository documentation and local workspace guidance so the split-repository workflow is understandable and usable from one VS Code workspace.
+
+## Proposed Implementation
+
+Document the local workspace shape:
+
+```text
+projects/
+  mylifeindigital/
+  mylifeindigital.content/
+  mylifeindigital.code-workspace
+```
+
+Update or add documentation for:
+
+- opening `mylifeindigital` and `mylifeindigital.content` together in one VS Code workspace;
+- the role of `mylifeindigital` as the application/code/docs/change-request repository;
+- the role of `mylifeindigital.content` as the publishable Markdown repository;
+- the application repository `content/` README placeholder after migration;
+- where `CONTENT_DIR` should be configured locally;
+- how local build and content-authoring commands relate to the sibling content checkout;
+- how the application README should be maintained after content moves out.
+
+The application README should be repurposed as a profile/showcase and repository-orientation document. It may link to the companion content repository and published site, but it should not try to maintain a full session log or publishable content catalog if that duplicates the content repository.
+
+## Acceptance Criteria
+
+- [ ] A VS Code workspace file or documented workspace setup shows `mylifeindigital` and `mylifeindigital.content` together.
+- [ ] Documentation explains that VS Code remains the near-term Markdown editing tool.
+- [ ] Documentation explains that the Electron/content operations app is future tooling and not required for normal near-term authoring.
+- [ ] The application repository README is updated or scoped so it no longer duplicates publishable content catalog responsibilities after the split.
+- [ ] The application repository `content/` placeholder README explains that publishable content lives in `mylifeindigital.content/content/`.
+- [ ] Local setup docs explain the root `.env` / `CONTENT_DIR` convention.
+- [ ] Local setup docs explain the normal local build/preview flow after the split.
+- [ ] Documentation distinguishes app repo docs/wiki/change requests from publishable content.
+- [ ] Links between the application repository and content repository are clear.
+
+## Implementation Notes
+
+- Depends on the repository decision in `CR-007`.
+- Coordinates with `CR-020`, which creates the content repository and migrates files.
+- Coordinates with `CR-021`, which adds `CONTENT_DIR` support to tooling.
+- Coordinates with `CR-019`, which adds GitHub Actions CI/CD.
+- The README should continue to support the application repository as a showcase of thinking, code experiments, docs/wiki workflow, and change-request workflow.
+- Related source notes: `docs/raw/repo-migration-notes.md`, `docs/raw/content-split.md`, and `docs/raw/authoring-flows.md`.
+
+## Outcome
+
+Pending implementation.

--- a/change-requests/CR-023-establish-baseline-test-setup.md
+++ b/change-requests/CR-023-establish-baseline-test-setup.md
@@ -1,0 +1,42 @@
+# CR-023: Establish Baseline Test Setup
+
+Status: Proposed  
+Priority: Medium  
+Area: Quality  
+Created: 2026-06-16
+
+## Context
+
+`CR-007` and the split-repository migration plan identify GitHub Actions validation as part of the future publishing workflow. The project does not currently have enough test coverage for tests to be treated as the primary deployment blocker.
+
+The initial migration should rely on build/typecheck/content validation first, while adding useful tests over time. This request creates a focused place to define and implement the first reliable test setup without expanding `CR-019` beyond CI/CD orchestration.
+
+## Goal
+
+Establish a small, reliable baseline test setup that can grow into meaningful CI quality gates for the application and content pipeline.
+
+## Proposed Implementation
+
+- Choose the project test runner and command structure using existing Node.js and TypeScript conventions.
+- Add minimal tests that provide real signal for high-risk behavior, such as content processing, frontmatter validation, generated content shape, or build-pipeline assumptions.
+- Add npm scripts for running the tests locally and in CI.
+- Document which checks are required immediately and which tests can become required once coverage is meaningful.
+- Keep deployment blocking focused on useful checks rather than treating a low-coverage test suite as false confidence.
+
+## Acceptance Criteria
+
+- [ ] A test runner and test command are selected for the app/code repository.
+- [ ] At least one high-signal baseline test is added.
+- [ ] Test commands are documented for local use and future CI use.
+- [ ] The relationship between tests, content validation, typecheck, build, and deployment blocking is documented.
+- [ ] `CR-019` can reference the resulting test command once it provides useful CI signal.
+
+## Implementation Notes
+
+- Related to `CR-019`, but not required before the first no-deploy CI migration phase.
+- Related to `CR-013`, which owns broader CI content validation checks.
+- Initial migration blockers remain dependency install, cross-repository checkout, `CONTENT_DIR`, `web/scripts/build-posts.ts`, generated `web/src/utils/posts-data.ts`, content validation, and web build/typecheck.
+
+## Outcome
+
+Pending implementation.

--- a/change-requests/index.md
+++ b/change-requests/index.md
@@ -20,7 +20,7 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 | CR-004 | Remove Monaco editor from web admin | Done | Medium | Web Admin | 2026-05-06 | [CR-004-remove-monaco-editor-from-web-admin.md](./CR-004-remove-monaco-editor-from-web-admin.md) |
 | CR-005 | Decide Electron vs Tauri for content operations app | Done | High | Content Operations | 2026-05-06 | [CR-005-decide-electron-vs-tauri-for-content-operations-app.md](./CR-005-decide-electron-vs-tauri-for-content-operations-app.md) |
 | CR-006 | Define content operations app scope and workflows | Done | High | Content Operations | 2026-05-06 | [CR-006-define-content-operations-app-scope-and-workflows.md](./CR-006-define-content-operations-app-scope-and-workflows.md) |
-| CR-007 | Decide single repo vs split content repository | Proposed | High | Architecture | 2026-05-06 | Pending detail |
+| CR-007 | Decide single repo vs split content repository | Proposed | High | Architecture | 2026-05-06 | [CR-007-decide-single-repo-vs-split-content-repository.md](./CR-007-decide-single-repo-vs-split-content-repository.md) |
 | CR-008 | Define publishing workflow rules | Proposed | High | Publishing | 2026-05-06 | Pending detail |
 | CR-009 | Add admin metadata editing UI | Proposed | Medium | Web Admin | 2026-05-06 | Pending detail |
 | CR-010 | Add admin validation panel and author-facing warnings | Proposed | High | Web Admin | 2026-05-06 | Pending detail |
@@ -36,10 +36,10 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 
 ### 2026-05-23
 
-- Detail coverage: `CR-001` through `CR-006` and `CR-015` through `CR-017` have detail files. `CR-007` through `CR-014` remain lightweight proposed rows and need detail files before they move toward planning or implementation.
+- Detail coverage: `CR-001` through `CR-007` and `CR-015` through `CR-017` have detail files. `CR-008` through `CR-014` remain lightweight proposed rows and need detail files before they move toward planning or implementation.
 - Status reconciliation: `CR-005` is complete in the dashboard and now matches its detail file status. Its acceptance criteria are checked and its outcome records the Electron decision.
 - Completed follow-up slices: `CR-015` and `CR-016` completed two concrete follow-ups from `CR-006`: template-driven content generation and standalone About rendering.
-- High-priority decisions: `CR-007` and `CR-008` remain proposed architecture/publishing decisions. `CR-006` noted their overlap but did not resolve them.
+- High-priority decisions: `CR-007` now has a detail file outlining the repository-boundary decision criteria. `CR-008` remains a proposed publishing decision without a detail file. `CR-006` noted their overlap but did not resolve them.
 - Related admin work: `CR-009` and `CR-010` should be detailed together before implementation so metadata editing and validation-panel boundaries stay clear.
 - Related pipeline work: `CR-011`, `CR-012`, `CR-013`, and `CR-014` overlap around preview, parsing, validation, and generated artifacts. Detail files should clarify dependencies before any one of them moves to `Planned`.
 

--- a/change-requests/index.md
+++ b/change-requests/index.md
@@ -21,33 +21,46 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 | CR-005 | Decide Electron vs Tauri for content operations app | Done | High | Content Operations | 2026-05-06 | [CR-005-decide-electron-vs-tauri-for-content-operations-app.md](./CR-005-decide-electron-vs-tauri-for-content-operations-app.md) |
 | CR-006 | Define content operations app scope and workflows | Done | High | Content Operations | 2026-05-06 | [CR-006-define-content-operations-app-scope-and-workflows.md](./CR-006-define-content-operations-app-scope-and-workflows.md) |
 | CR-007 | Decide single repo vs split content repository | Proposed | High | Architecture | 2026-05-06 | [CR-007-decide-single-repo-vs-split-content-repository.md](./CR-007-decide-single-repo-vs-split-content-repository.md) |
-| CR-008 | Define publishing workflow rules | Proposed | High | Publishing | 2026-05-06 | Pending detail |
+| CR-008 | Define publishing workflow rules | Proposed | High | Publishing | 2026-05-06 | [CR-008-define-publishing-workflow-rules.md](./CR-008-define-publishing-workflow-rules.md) |
 | CR-009 | Add admin metadata editing UI | Proposed | Medium | Web Admin | 2026-05-06 | Pending detail |
 | CR-010 | Add admin validation panel and author-facing warnings | Proposed | High | Web Admin | 2026-05-06 | Pending detail |
 | CR-011 | Spike browser-worker preview pipeline | Proposed | Medium | Content Pipeline | 2026-05-06 | Pending detail |
 | CR-012 | Decide parser roadmap for markdown processing | Proposed | Medium | Content Pipeline | 2026-05-06 | Pending detail |
 | CR-013 | Add CI content validation checks | Proposed | Medium | Quality | 2026-05-06 | Pending detail |
-| CR-014 | Reassess generated content artifact strategy | Proposed | Medium | Architecture | 2026-05-06 | Pending detail |
+| CR-014 | Reassess generated content artifact strategy | Proposed | Medium | Architecture | 2026-05-06 | [CR-014-reassess-generated-content-artifact-strategy.md](./CR-014-reassess-generated-content-artifact-strategy.md) |
 | CR-015 | Template-driven content generator | Done | High | Content Operations | 2026-05-21 | [CR-015-template-driven-content-generator.md](./CR-015-template-driven-content-generator.md) |
 | CR-016 | Render standalone About content | Done | High | Web Content | 2026-05-21 | [CR-016-render-standalone-about-content.md](./CR-016-render-standalone-about-content.md) |
 | CR-017 | Convert docs to LLM wiki | Done | Medium | Process | 2026-05-23 | [CR-017-convert-docs-to-llm-wiki.md](./CR-017-convert-docs-to-llm-wiki.md) |
 | CR-018 | Decide web admin role after content repository split | Proposed | Medium | Web Admin | 2026-05-29 | [CR-018-decide-web-admin-role-after-content-repository-split.md](./CR-018-decide-web-admin-role-after-content-repository-split.md) |
 | CR-019 | Implement split-repository GitHub Actions CI/CD | Proposed | High | Deployment | 2026-06-14 | [CR-019-implement-split-repository-github-actions-ci-cd.md](./CR-019-implement-split-repository-github-actions-ci-cd.md) |
+| CR-020 | Create content repository and migrate files | Proposed | High | Architecture | 2026-06-16 | [CR-020-create-content-repository-and-migrate-files.md](./CR-020-create-content-repository-and-migrate-files.md) |
+| CR-021 | Add CONTENT_DIR support to content tooling | Proposed | High | Content Pipeline | 2026-06-16 | [CR-021-add-content-dir-support-to-content-tooling.md](./CR-021-add-content-dir-support-to-content-tooling.md) |
+| CR-022 | Update README, workspace, and local docs | Proposed | Medium | Documentation | 2026-06-16 | [CR-022-update-readme-workspace-and-local-docs.md](./CR-022-update-readme-workspace-and-local-docs.md) |
+| CR-023 | Establish baseline test setup | Proposed | Medium | Quality | 2026-06-16 | [CR-023-establish-baseline-test-setup.md](./CR-023-establish-baseline-test-setup.md) |
 
 ## Backlog Grooming Notes
 
+### 2026-06-16
+
+- Added `CR-020` as the focused implementation request for creating `mylifeindigital.content` and migrating publishable Markdown files.
+- Added `CR-021` as the focused implementation request for adding `CONTENT_DIR` support to build and content-authoring tooling.
+- Added `CR-022` as the focused documentation request for README, VS Code workspace, and local split-repository setup guidance.
+
 ### 2026-06-14
 
+- Added the `CR-008` detail file to define publishing lifecycle, readiness, trigger, failure, and rollback rules for the split-repository model.
+- Added the `CR-014` detail file to define generated content artifact ownership, review, deployment, and rollback strategy.
 - Added `CR-019` as the implementation follow-up for GitHub Actions validation and deployment across the application and content repositories.
+- Added `CR-023` as the focused follow-up for establishing baseline test setup without expanding `CR-019`.
 - The application repository owns the only production deployment workflow; the content repository validates content and requests deployment.
 - `CR-019` depends on the repository decision in `CR-007` and should align with publishing rules in `CR-008`, content validation in `CR-013`, and generated artifact handling in `CR-014`.
 
 ### 2026-05-23
 
-- Detail coverage: `CR-001` through `CR-007` and `CR-015` through `CR-017` have detail files. `CR-008` through `CR-014` remain lightweight proposed rows and need detail files before they move toward planning or implementation.
+- Detail coverage at this pass: `CR-001` through `CR-008` and `CR-015` through `CR-019` have detail files. `CR-009` through `CR-014` remain lightweight proposed rows and need detail files before they move toward planning or implementation.
 - Status reconciliation: `CR-005` is complete in the dashboard and now matches its detail file status. Its acceptance criteria are checked and its outcome records the Electron decision.
 - Completed follow-up slices: `CR-015` and `CR-016` completed two concrete follow-ups from `CR-006`: template-driven content generation and standalone About rendering.
-- High-priority decisions: `CR-007` now has a detail file outlining the repository-boundary decision criteria. `CR-008` remains a proposed publishing decision without a detail file. `CR-006` noted their overlap but did not resolve them.
+- High-priority decisions: `CR-007` defines the repository boundary and `CR-008` now defines the publishing workflow rules that `CR-019` should implement.
 - Related admin work: `CR-009` and `CR-010` should be detailed together before implementation so metadata editing and validation-panel boundaries stay clear.
 - Related pipeline work: `CR-011`, `CR-012`, `CR-013`, and `CR-014` overlap around preview, parsing, validation, and generated artifacts. Detail files should clarify dependencies before any one of them moves to `Planned`.
 

--- a/change-requests/index.md
+++ b/change-requests/index.md
@@ -32,8 +32,15 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 | CR-016 | Render standalone About content | Done | High | Web Content | 2026-05-21 | [CR-016-render-standalone-about-content.md](./CR-016-render-standalone-about-content.md) |
 | CR-017 | Convert docs to LLM wiki | Done | Medium | Process | 2026-05-23 | [CR-017-convert-docs-to-llm-wiki.md](./CR-017-convert-docs-to-llm-wiki.md) |
 | CR-018 | Decide web admin role after content repository split | Proposed | Medium | Web Admin | 2026-05-29 | [CR-018-decide-web-admin-role-after-content-repository-split.md](./CR-018-decide-web-admin-role-after-content-repository-split.md) |
+| CR-019 | Implement split-repository GitHub Actions CI/CD | Proposed | High | Deployment | 2026-06-14 | [CR-019-implement-split-repository-github-actions-ci-cd.md](./CR-019-implement-split-repository-github-actions-ci-cd.md) |
 
 ## Backlog Grooming Notes
+
+### 2026-06-14
+
+- Added `CR-019` as the implementation follow-up for GitHub Actions validation and deployment across the application and content repositories.
+- The application repository owns the only production deployment workflow; the content repository validates content and requests deployment.
+- `CR-019` depends on the repository decision in `CR-007` and should align with publishing rules in `CR-008`, content validation in `CR-013`, and generated artifact handling in `CR-014`.
 
 ### 2026-05-23
 

--- a/change-requests/index.md
+++ b/change-requests/index.md
@@ -31,6 +31,7 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 | CR-015 | Template-driven content generator | Done | High | Content Operations | 2026-05-21 | [CR-015-template-driven-content-generator.md](./CR-015-template-driven-content-generator.md) |
 | CR-016 | Render standalone About content | Done | High | Web Content | 2026-05-21 | [CR-016-render-standalone-about-content.md](./CR-016-render-standalone-about-content.md) |
 | CR-017 | Convert docs to LLM wiki | Done | Medium | Process | 2026-05-23 | [CR-017-convert-docs-to-llm-wiki.md](./CR-017-convert-docs-to-llm-wiki.md) |
+| CR-018 | Decide web admin role after content repository split | Proposed | Medium | Web Admin | 2026-05-29 | [CR-018-decide-web-admin-role-after-content-repository-split.md](./CR-018-decide-web-admin-role-after-content-repository-split.md) |
 
 ## Backlog Grooming Notes
 

--- a/docs/raw/authoring-flows.md
+++ b/docs/raw/authoring-flows.md
@@ -1,0 +1,65 @@
+# Authoring Flows
+
+> The decision identifies how browser admin, Electron/content operations, terminal, and script-based authoring flows are affected.
+
+The project is moving toward a split where publishable Markdown content lives in `mylifeindigital.content` while application code, build pipeline, docs, and change requests stay in `mylifeindigital`.
+
+Git has been identified as a key component. The content hosted in a Git repo will remain the single source of truth. That raises an important authoring question: should content operations happen through a browser admin that uses vendor APIs such as the GitHub API, or through an Electron app that operates on a local Git checkout?
+
+At this stage, the stronger direction is the local Git checkout model. A Git repo works the same way regardless of whether it is hosted on GitHub or somewhere else. A local desktop app can run Git commands and local npm scripts directly, avoid extra HTTP/API translation for routine operations, and avoid making the authoring model depend too heavily on one hosting vendor's API.
+
+## Authoring Path
+
+The preferred authoring path after the split is:
+
+1. VS Code remains the near-term Markdown editing tool.
+2. Terminal and scripts remain supported for generation, validation, build, Git, and recovery workflows.
+3. The Electron content operations app becomes the preferred future content operations surface once it is mature enough for daily use.
+4. Browser admin is not the primary content authoring path and should be treated as deprecated for publishable content unless a clear bounded role is defined.
+
+The browser admin should not continue as an ambiguous write-capable content editor if it no longer matches the Git-first split-repository model. A follow-up change request should decide whether to remove it, make it read-only, or keep a narrow emergency/admin/status role.
+
+## Browser Admin
+
+The browser admin should no longer be treated as the primary long-term authoring surface for publishable content.
+
+If browser admin content editing remains, it would need to write to the content repository through a remote API such as the GitHub API. That may still be useful for lightweight edits or emergency changes, but it creates vendor-specific coupling and does not feel as close to the Git-first local workflow.
+
+The browser admin can remain useful for repository/app operations that are naturally web-based, read-only inspection, or future remote workflows. It should not be the first place where the split content repository workflow is optimized.
+
+## Electron Content Operations App
+
+The Electron app is the preferred future content operations surface.
+
+The app should operate on the local `mylifeindigital.content` checkout and use local Git and npm/script operations where practical. One of the main ideas is for the Electron app to run local npm scripts, validation commands, content generation commands, preview/build commands, and Git operations from a controlled UI.
+
+Electron is attractive because it can access local desktop resources and local repositories directly. It can support the Git-first workflow without translating every content operation into GitHub API calls.
+
+The Electron app should focus on content creation and operations, not on editing the code used to build the editor. Normal content work should happen against the content repository/workspace.
+
+## Terminal Authoring
+
+Terminal authoring should remain a supported power-user and agent workflow.
+
+The terminal should be able to run content creation, validation, build, and Git commands against the content repository and selected application pipeline. This keeps the system debuggable and avoids making the Electron app a required dependency for all content work.
+
+Terminal workflows are especially useful for Codex-assisted changes, scripted maintenance, validation, and recovery when the desktop app is not available or not mature enough.
+
+## Script-Based Authoring
+
+Script-based authoring should continue, but scripts must stop assuming that publishable Markdown lives inside the application repository.
+
+Scripts such as `scripts/new-content.ts` should be updated to accept a configurable content repository path, likely through `CONTENT_DIR` or a similar setting. New content should be written to `mylifeindigital.content`, not to the application repository's current Git branch.
+
+The scripts can continue to live in the application repository if they are part of the content operations/build tooling, but their file operations should target the content repository. This keeps script behavior aligned with the split source-of-truth model while preserving the existing Node-based tooling direction.
+
+## Near-Term Editing Tool
+
+VS Code remains the near-term Markdown editing tool until the Electron content operations app is mature enough for daily use.
+
+The practical local workflow is to open both repositories in one VS Code workspace:
+
+- `mylifeindigital` for code, docs, change requests, scripts, and experiments.
+- `mylifeindigital.content` for publishable content.
+
+This keeps the split repository model usable without forcing separate editor windows or making content work depend on the Electron app before it is ready.

--- a/docs/raw/branching-workflows.md
+++ b/docs/raw/branching-workflows.md
@@ -1,0 +1,28 @@
+# Branching notes
+
+## Git Branching Strategy
+
+- The understanding is that we will split the code repo and the content repo into their own respective repos. Thus the branching for the code repository would follow a conventional approach: for new change requests we create a change-request branch - not sure if it should be an explicit feature branch and whether we would configure CI/CD with multiple deployable environments - seems overkill to have to create separate hosted environments. For change-requests we create a branch from main and do the dev work. 
+- For content creation I'm not sure whether creating separate branches is needed? If I write some new content it should have draft status set to true by default. Why would you want to create a separate branch for the content?
+
+## Protecting main (default) branches
+
+Protect `main` in both the application and content repositories before enabling GitHub Actions production deployment.
+
+Baseline protection:
+
+- Require changes to reach `main` through a pull request.
+- Require relevant CI checks to pass before merge.
+- Block force pushes and branch deletion.
+- Require review conversations to be resolved.
+- Do not require another person's approval initially because this is a single-author project.
+- Allow administrative bypass only for recovery, not routine work.
+
+GitHub Actions should separate validation from production deployment:
+
+- Pull requests run build-only validation and do not deploy.
+- Application `main` merges validate the selected application and content commits, then deploy their combined Worker bundle.
+- Content `main` merges trigger the same production deployment workflow because content must be compiled into `web/src/utils/posts-data.ts`.
+- Only one workflow should own production deployment to avoid duplicate or competing deployments.
+
+The application and content repositories have separate change histories, but deployment combines an application commit and content commit into one Worker artifact.

--- a/docs/raw/content-authoring.md
+++ b/docs/raw/content-authoring.md
@@ -1,0 +1,5 @@
+# Content Authoring
+
+## VSCode
+
+VSCode is a great Markdown editor. As such it will remain the default choice. The goal with the project eventually will be to have an Electron editor focused solely on the content authoring. I foresee it providing features for processing and organizing content as well as publishing content. I do not see the Electron app being used to edit and run code. VSCode will remain a tool for viewing source code as well. 

--- a/docs/raw/content-planning.md
+++ b/docs/raw/content-planning.md
@@ -1,0 +1,3 @@
+# Content Planning
+
+There are times when it would help to have an assistant provide a structured content plan. What would be some of the most practical ways to suggest content?

--- a/docs/raw/content-split.md
+++ b/docs/raw/content-split.md
@@ -1,0 +1,73 @@
+# Content Split
+
+## Local Development
+
+Local development should use two separate Git repositories in one VS Code workspace:
+
+- `mylifeindigital` - application code, build pipeline, docs, change requests, and experiments.
+- `mylifeindigital.content` - publishable Markdown content and content-owned assets.
+
+VS Code remains the near-term Markdown editing tool until the Electron content operations app is mature enough for daily use. The Electron app should eventually improve content creation workflows, but it should operate on the content repository rather than requiring normal content work to happen inside the application codebase.
+
+The application repo should support a configurable content path, likely `CONTENT_DIR`, so local builds can point at the sibling content checkout:
+
+```text
+CONTENT_DIR=../mylifeindigital.content/content
+```
+
+Local content preview should follow this loop:
+
+1. Open both repositories in one VS Code workspace.
+2. Edit or create Markdown in `mylifeindigital.content`.
+3. Run the app build or dev command from `mylifeindigital/web`.
+4. `web/scripts/build-posts.ts` reads content from `CONTENT_DIR`.
+5. The app generates `web/src/utils/posts-data.ts`.
+6. The local Worker/dev server renders the selected content.
+
+Application work and content work should use separate Git status and branch state. Creating or editing content should not dirty the application repo unless the build pipeline, templates, schemas, or rendering code also need changes.
+
+## CI Validation
+
+### Code repo changes
+
+- Install dependencies.
+- Typecheck/build the app.
+- Run relevant tests.
+- Build against the latest approved content commit, or the configured default content branch.
+- Validate that `build-posts` can read the selected content repository commit.
+
+### Content repo changes
+
+- Validate frontmatter/schema.
+- Run `build-posts` against the app pipeline.
+- Check drafts/excludes/images/metadata rules.
+- Confirm `web/src/utils/posts-data.ts` can be generated without treating it as authored content.
+
+### Image generation
+
+Image generation should not be required for every content validation run. CI should validate Markdown, frontmatter, schema rules, drafts, excludes, and build compatibility without depending on OpenAI credits or API key health.
+
+OpenAI-backed image generation should be a separate explicit workflow or optional CI job. That job can fail clearly when credentials, credits, or provider availability are invalid, without blocking ordinary content validation unless the content being published requires generated images.
+
+## Rendered Preview Validation
+
+There are no preview deployments in the current workflow. Preview deployments are intentionally out of scope for the initial split because they add operational overhead.
+
+The initial workflow should rely on local preview, schema/build validation, and production deployment through GitHub Actions.
+
+Playwright may add value for local rendered validation, CI smoke tests, or release validation, but it should not be the first validation layer for content changes. Start with schema/build validation, then add Playwright if rendered-page confidence becomes important, such as checking article routes, standalone pages, metadata rendering, and image presence.
+
+Preview deployments should be reconsidered if rendered review, branch-based app/content pairing, or pre-production visual validation becomes a recurring need.
+
+## Production Deployment
+
+Production deployment should be orchestrated by GitHub Actions.
+
+The workflow should check out:
+
+- `mylifeindigital` from the selected application ref.
+- `mylifeindigital.content` from the selected content ref.
+
+The workflow should set `CONTENT_DIR`, run validation, generate `web/src/utils/posts-data.ts`, and deploy with `wrangler deploy`.
+
+Each deployment should log the application commit SHA and content commit SHA.

--- a/docs/raw/llm-wiki-ideas.md
+++ b/docs/raw/llm-wiki-ideas.md
@@ -1,0 +1,220 @@
+Yes, there is a business case — but **not as “another AI wiki app.”** That category is already getting noisy fast.
+
+The value is in applying the LLM-wiki pattern to a **painful, specific knowledge problem** where normal docs fail.
+
+Karpathy’s pattern, as described in recent writeups, is roughly: store knowledge in Markdown/GitHub, let an LLM help structure/query/synthesize it, and keep it lightweight instead of building a huge app around it. The appeal is that it turns messy raw knowledge into a structured, queryable knowledge base without a heavy CMS. ([MindStudio][1])
+
+## My honest take
+
+**The business case is strongest as a service/package, not a SaaS product — at least at first.**
+
+For My Life in Digital, I would think of it as:
+
+> “We help small teams turn messy business knowledge into a useful AI-ready wiki.”
+
+That is much more sellable than:
+
+> “Here is my cool Cloudflare/Hono LLM wiki platform.”
+
+The platform can exist behind the scenes. But the thing people pay for is usually the outcome:
+
+* fewer repeated questions
+* easier onboarding
+* better handover
+* less knowledge trapped in one person’s head
+* easier access to policies, product info, FAQs, processes, and client instructions
+* cleaner internal documentation
+
+## Where this has real value
+
+I see four good business angles.
+
+### 1. Small business operations wiki
+
+This could fit My Life in Digital very well.
+
+Target customer:
+
+Small businesses with messy WhatsApps, spreadsheets, Google Docs, staff instructions, price lists, product notes, supplier info, and “ask Susan, she knows” knowledge.
+
+Offer:
+
+> “We organise your business knowledge into a simple internal wiki that you and your team can search, update, and reuse.”
+
+Examples:
+
+* product catalogue notes
+* order process
+* supplier details
+* pricing rules
+* customer FAQ
+* returns/refunds policy
+* staff onboarding
+* recurring task checklists
+* marketing copy snippets
+
+This is not glamorous AI. That is good. Glamorous AI often has no buyer. Boring AI with admin relief has buyers.
+
+### 2. Developer/team knowledge base
+
+This one connects directly to your Media24 world.
+
+Target customer:
+
+Software teams with undocumented repos, migration leftovers, API quirks, deployment steps, tribal knowledge, and onboarding pain.
+
+Offer:
+
+> “We turn your repos, READMEs, Confluence pages, runbooks, and architecture notes into a living engineering wiki.”
+
+Examples:
+
+* system overview
+* repo map
+* API map
+* deployment notes
+* known gotchas
+* test coverage notes
+* ownership areas
+* incident learnings
+* onboarding guide
+
+This is valuable, but selling into engineering teams as a side business can be harder unless you already have access to those networks.
+
+### 3. Personal knowledge system for professionals
+
+Target customer:
+
+Consultants, coaches, creators, academics, researchers, independent experts.
+
+Offer:
+
+> “Turn your notes, documents, frameworks, and content into an AI-searchable personal knowledge base.”
+
+This has appeal, but it can become fiddly because every person’s brain filing system is a crime scene with a search bar.
+
+### 4. Content-to-wiki publishing engine
+
+Target customer:
+
+Businesses with lots of content: blog posts, training docs, product help, PDFs.
+
+Offer:
+
+> “We convert your existing content into a structured public or private knowledge hub.”
+
+This could become productised later.
+
+## What I would not do yet
+
+I would **not** start by building a full generic app with:
+
+* user accounts
+* billing
+* workspaces
+* permissions
+* custom editor
+* real-time sync
+* AI chat
+* dashboards
+* plugin system
+* importers for everything under the sun
+
+That is how you accidentally start building Notion, Confluence, Guru, Obsidian Publish, and a tiny nervous breakdown all at once.
+
+Build the service first. Let the product emerge from repeated client needs.
+
+## The strongest My Life in Digital positioning
+
+I’d position it like this:
+
+> **AI-ready business wikis for small teams.**
+> We turn your scattered documents, processes, FAQs, product info, and internal know-how into a clean, searchable knowledge base your team can actually use.
+
+That is clear. It has a buyer. It does not require explaining Karpathy to a florist, accountant, school, resin gift business, or local service company.
+
+The buyer does not care that it is “LLM wiki style.” They care that staff stop asking the same question 20 times.
+
+## Possible product packages
+
+You could make this very practical.
+
+| Package                    | What it includes                                                   | Good for                  |
+| -------------------------- | ------------------------------------------------------------------ | ------------------------- |
+| **Starter Knowledge Base** | 10–20 core pages, structure, search-ready markdown, simple hosting | Small business basics     |
+| **Operations Wiki**        | Processes, FAQs, staff checklists, supplier/customer info          | Teams with repeated admin |
+| **Engineering Wiki**       | Repo map, architecture notes, API docs, onboarding guide           | Small dev teams           |
+| **Content Wiki**           | Existing posts/docs turned into structured hub                     | Creators/consultants      |
+
+For now, I’d avoid pricing it too cheaply. This is thinking work, not just typing. The value is the structuring.
+
+## The product you build behind it
+
+Since you already have Cloudflare + Hono, a sensible technical version could be:
+
+* Markdown/content files as source of truth
+* Git-backed or file-backed content
+* Static/public pages
+* Private pages later
+* Search index
+* Optional LLM-generated summaries
+* “Ask this wiki” later
+* Admin/editor much later
+
+First version could simply be:
+
+**Markdown → structured site → search → contact CTA**
+
+Then add AI features only where they clearly help.
+
+## The business test
+
+Before building much more, create one page on My Life in Digital:
+
+**“AI-Ready Business Wiki Setup”**
+
+Include:
+
+* who it is for
+* what problem it solves
+* what you need from the client
+* what they receive
+* examples of pages
+* starting price or “from R___”
+* contact/WhatsApp CTA
+
+Then test it with 5–10 real people/business owners.
+
+The validation question is not:
+
+> “Do you think this is cool?”
+
+People lie politely.
+
+The better question is:
+
+> “Where does your business knowledge currently live, and what breaks because of that?”
+
+If they start ranting, you have a market.
+
+## My recommendation
+
+Yes, explore this spin.
+
+But I’d frame it as:
+
+**My Life in Digital helps small businesses and teams organise their knowledge into simple AI-ready wikis.**
+
+Then build only enough to support a demo and a service offer.
+
+For your own backlog, I’d create one concrete 2-week objective:
+
+> Launch a public “Business Wiki Setup” service page with one working demo wiki.
+
+Use My Life in Print as the demo. That is perfect because you already have real complexity: product info, customisation rules, order processes, FAQs, delivery rules, pricing logic, image requirements, lead times, and marketing copy.
+
+That would make the idea tangible immediately.
+
+And honestly? This is a better side-project direction than another generic dev blog. It combines your engineering skill, your small business context, your AI interest, and an actual business pain. That overlap is where the good stuff usually lives.
+
+[1]: https://www.mindstudio.ai/blog/andrej-karpathy-llm-wiki-knowledge-base-claude-code/?utm_source=chatgpt.com "What Is Andrej Karpathy's LLM Wiki? How to Build a ..."

--- a/docs/raw/paywall.md
+++ b/docs/raw/paywall.md
@@ -1,0 +1,3 @@
+# Paywall
+
+If I ever consider introducing a paywall in the future I would have to change the way I host the current version of the website? This is not a change to be considered in the current change request. I am treating the raw folder as a place where i can capture ideas even for future exploration. 

--- a/docs/raw/repo-migration-notes.md
+++ b/docs/raw/repo-migration-notes.md
@@ -1,0 +1,245 @@
+# Repo migration notes
+
+- Current repo mylifeindigital remains the app repo
+- Create a new repo mylifeindigital.content for the content repo
+- the [content folder](../../content/) to be moved to new repo. 
+  - first create local repo, mylifeindigital.content. create folder if none exists and init the repo
+  - create repo in GitHub, add remotes, push to repo
+  - will we need any gitignore for the markdown repo?
+- will need to disable Cloudflare hook integration with GH so as to not trigger deployment during migration. Will move to GH actions.
+- keep the planned Electron/content operations app code in `mylifeindigital`; it is app/editor implementation code, not publishable content.
+
+## Repository ownership
+
+- `mylifeindigital.content` owns publishable Markdown and content-owned assets. 
+- `mylifeindigital` owns app code, build pipeline, scripts, docs, CRs, and the Electron/content operations app code. Just want to guard against single code repo becoming a catchall. Need to be specific about what lives in the repo:
+  - app code: Hono app that drives current `www.mylifeindigital.co.za`
+  - desktop app code: Electron/content operations POC
+  - note that both app and desktop code will use NodeJS. The code that exists in this repo is for mylifeindigital only - and only aspects related to it. any other POCs or new projects get their own repos. 
+
+## Migration boundary
+
+For the initial migration, move only the publishable content source tree:
+
+- `content/index.md`
+- `content/pages/`
+- `content/posts/`
+- `content/technical-sessions/`
+
+Technical sessions move with the content repository because they are still rendered by the web app as publishable content. They are learning logs, but operationally they behave like content rather than application code. At the time of this note, the technical-session files do not carry `draft: true` frontmatter, so the migration should treat them as publishable unless a separate content review changes their status before cutover.
+
+Do not move `web/public/`, `docs/`, `change-requests/`, app source, build scripts, or generated runtime artifacts.
+
+Existing generated images are not local content files. They are stored remotely in Cloudflare/R2 and referenced through generated metadata. The current `web/scripts/image-manifest.json` remains in the app repository during the initial cutover because it is coupled to the current image-generation scripts.
+
+A follow-up generated-artifact/image decision should decide whether image manifest state eventually moves into the content repository, remains app-owned, or becomes CI/object-storage managed.
+
+## Repository folder structure
+
+- `mylifeindigital`:
+  - `change-requests/` - local-first change requests.
+  - `content/` - README placeholder only after migration.
+  - `docs/` - code-adjacent notes, wiki sources, and project memory.
+  - `experiments/` - code experiments tied to the project.
+  - `scripts/` - repository-level tooling.
+  - `web/` - Hono app for `www.mylifeindigital.co.za`.
+  - future Electron/content operations app code - editor implementation source.
+
+- `mylifeindigital.content`:
+  - `content/index.md`
+  - `content/pages/`
+  - `content/posts/`
+  - `content/technical-sessions/`
+  - `.gitignore`
+  - `README.md`
+
+## App repo `content/` after migration
+
+After cutover, `mylifeindigital/content/` should remain only as a README placeholder. It should not contain publishable Markdown.
+
+The placeholder should explain:
+
+- publishable content now lives in `mylifeindigital.content/content/`;
+- local builds should set `CONTENT_DIR`;
+- the app repo no longer owns publishable content source files.
+
+During migration, `build-posts.ts` may temporarily fall back to the app repo `content/` path so the transition can be staged safely. After GitHub Actions and local workflows are stable, remove the fallback and keep `CONTENT_DIR` required for split-repo builds.
+
+## VS Code Workspace
+
+projects/
+  mylifeindigital/
+  mylifeindigital.content/
+  mylifeindigital.code-workspace
+
+## Build integration
+
+Add that `web/scripts/build-posts.ts` should read `CONTENT_DIR`, falling back to the current repo `content/` only during transition. **question** does all the code in web get deployed?
+
+## Shared `CONTENT_DIR` convention
+
+Use `CONTENT_DIR` as the shared environment variable for the publishable content source path:
+
+```text
+CONTENT_DIR=../mylifeindigital.content/content
+```
+
+The root `.env` file should be the canonical local content-tooling configuration because both root scripts and web build scripts need the same content path.
+
+Tools should resolve content in this order:
+
+1. Use `CONTENT_DIR` from the process environment when set.
+2. Load `CONTENT_DIR` from the root `.env` for local tooling.
+3. During migration only, fall back to the app repo `content/` path.
+4. After the split is stable, remove the fallback and require `CONTENT_DIR` for split-repo builds.
+
+`web/.env` may still be used for web-specific build configuration, but it should not become a second competing source for the content repository path unless there is a clear reason.
+
+## Script integration
+
+`scripts/new-content.ts` should read the same `CONTENT_DIR` convention and write to the configured content repo path, not the app repo’s current branch.
+
+## CI/CD
+
+Reference [CR-019](../../change-requests/CR-019-implement-split-repository-github-actions-ci-cd.md): GitHub Actions checks out both repos, generates posts-data.ts, deploys with Wrangler, and Cloudflare native Git deployment is disabled only after Actions is verified. 
+
+What pipelines are needed though? As stated before when content is updated in `mylifeindigital.content` we have to invariably trigger [build-posts.ts](../../web/scripts/build-posts.ts) because it generates the output [posts-data.ts](../../web/src/utils/posts-data.ts). Even if no code has changed a build of the app code has to be triggered.
+
+Use phased GitHub Actions rather than starting with one deployment-only pipeline:
+
+1. Add app CI in `mylifeindigital` first. It should run on application PRs, check out the application repo plus the selected/default content repo ref, set `CONTENT_DIR`, generate `posts-data.ts`, and run the web build/typecheck without deploying.
+2. Add content CI in `mylifeindigital.content`. It should run on content PRs and validate that Markdown content can be processed by the application build pipeline without deploying.
+3. Add production deploy in `mylifeindigital` only after the no-deploy CI path is working. This should be the only workflow that runs `wrangler deploy`.
+
+Tests should be introduced going forward, but the initial split-repository migration should not depend on a test suite that does not exist yet or does not provide meaningful coverage. The first required CI blockers should be dependency install, cross-repository checkout, `CONTENT_DIR`, `build-posts.ts`, generated `posts-data.ts`, content validation, and the web build/typecheck. As useful tests are added, they can become required CI checks before production deployment.
+
+Cloudflare's native Git deployment can remain enabled while no-deploy app CI and content CI are introduced because those workflows do not publish anything. The risk appears when the GitHub Actions production deploy workflow is introduced: Cloudflare already deploys application `main`, so automatic GitHub Actions production triggers should not be enabled while the Cloudflare native trigger is still active.
+
+The deploy cutover should therefore be controlled:
+
+1. Add and validate no-deploy app/content CI.
+2. Add the GitHub Actions deploy workflow in explicit manual-dispatch mode.
+3. Run one verified GitHub Actions deployment with explicit application and content refs, or otherwise validate the workflow without enabling competing automatic production triggers.
+4. Disable or constrain Cloudflare native Git deployment.
+5. Enable GitHub Actions as the single automatic production deployment path.
+
+Manual-dispatch mode means the workflow is started intentionally with explicit refs during cutover. It does not mean adding a GitHub Environment approval gate. Manual approval gates are out of scope for the initial workflow.
+
+## Rollback path
+
+Add both rollback types:
+
+- deploy rollback: redeploy known-good app SHA + content SHA. If we added tests and prevented the build/deploy from continuing without passing tests would it add a layer of protection? preventing deployments could help? Manual approval gates are out of scope for the initial workflow.
+- content rollback: revert/fix content through a new content branch and PR. not sure about this yet
+
+## Cutover sequence
+
+- Create new folder `mylifeindigital.content`
+  - add `.gitignore` with entries for `.DS_Store`, `.env`, editor temp files, maybe generated/cache folders.
+- Create new `mylifeindigital.code-workspace` - verify
+- Move publishable `content/*` files into `mylifeindigital.content/content/`.
+- Replace app repo `content/` with a README placeholder.
+- Add `CONTENT_DIR` to the root `.env`
+- Test `build-posts.ts`, `new-content.ts`
+- Create new GH repo for `mylifeindigital.content`
+  - add remote to local folder
+  - push initial content
+  - setup protected branch on main
+- On existing GH repo `mylifeindigital` add branch protection on main
+- Add GH Actions
+- Validate no-deploy app/content CI
+- Add the GitHub Actions deploy workflow in explicit manual-dispatch mode
+- Run one verified GitHub Actions deployment with explicit application and content refs, or validate the deploy workflow without enabling competing automatic triggers
+- Disable or constrain Cloudflare native trigger
+- Enable GitHub Actions as the single automatic production deployment path
+
+Can the cutover sequence be used to create follow-up CRs?
+
+## Further critical questions
+
+Critical questions to clarify before this can satisfy the CR-007 migration-plan criterion:
+
+1. **What exactly moves to `mylifeindigital.content`?**
+   Does the new repo contain only `content/`, or also content-owned images/templates/manifests? Current note says “content-owned assets” but the cutover only moves `content/*`.
+
+   **answer**: how do we verify where the content assets live? currently [posts-data.ts](../../web/src/utils/posts-data.ts) references images hosted on Cloudflare. Part of the `build-posts.ts` logic uploads the images to Cloudflare. So it appears as if no images are stored locally. Lets verify
+
+2. **Should the new repo keep a top-level `content/` folder?**
+   I recommend yes: `mylifeindigital.content/content/...`. That makes `CONTENT_DIR=../mylifeindigital.content/content` explicit. But decide this now.
+
+   **answer**: yes
+
+3. **What happens to `content/` in the app repo after migration?**
+   Delete it, leave a README placeholder, or keep it temporarily as fallback? Your note says “Migrate = remove,” but `build-posts.ts` fallback says current repo `content/` remains during transition. Those conflict slightly.
+
+   **answer**: leave `mylifeindigital/content/` as a README placeholder only. It should not contain publishable Markdown after cutover. The fallback to app-repo `content/` is only temporary transition support and should be removed after GitHub Actions and local workflows are stable.
+
+4. **Where should `CONTENT_DIR` live locally?**
+   Should the path live in the root `.env`, `web/.env`, `web/.dev.vars`, or only as a documented shell environment variable? This matters because both root scripts and web build scripts need the same content repository path.
+
+   **answer**: question 4 and 5 are the same design decision. Use `CONTENT_DIR` as the shared environment variable and store it in the root `.env` for local content tooling because both root scripts and web build scripts need the same path. CI can pass `CONTENT_DIR` directly through the workflow environment.
+
+5. **Does `scripts/new-content.ts` read the same `CONTENT_DIR`?**
+   If root scripts and web scripts both need it, maybe define one shared env convention and document where each command loads it from.
+
+   **answer**: yes. `scripts/new-content.ts` and `web/scripts/build-posts.ts` should both use the same `CONTENT_DIR` convention. During migration they can fall back to the app repo `content/` path, but after the split is stable `CONTENT_DIR` should be required for split-repo builds and content creation.
+
+6. **Will `posts-data.ts` remain committed after the split?**
+   This affects rollback, diffs, and CI. You’ve noted it elsewhere, but the migration plan should make a transition decision: temporary committed artifact or generated-only.
+
+   **answer**: `posts-data.ts` should remain generated-only after the split. It is already ignored by `web/.gitignore` and is produced by `web/scripts/build-posts.ts` during the build. GitHub Actions should generate `posts-data.ts` in the workflow workspace after checking out both the application commit and the content commit, then deploy the resulting Worker bundle with Wrangler. The generated file should not be committed unless a later CR deliberately changes the artifact strategy.
+
+7. **Do technical sessions move to the content repo?**
+   The current `content/` folder includes posts, pages, and technical sessions. Confirm all publishable sections move, even if technical sessions are partly code-learning logs.
+
+   **answer**: keep technical sessions - they are still being rendered on the web. None of the technical session content has been updated with a draft status.
+
+8. **Where does the Electron POC live?**
+   Your instinct says keep it in `mylifeindigital`. I’d make that explicit: app/editor code stays in the app repo; only publishable content moves.
+
+    **answer**: app/editor code stays in app repo
+
+9. **What is the minimum first GitHub Actions setup?**
+   Do you want one initial deploy workflow only, or separate `app-ci`, `content-ci`, and `deploy` from the start? CR-019 describes the full target, but migration can phase it.
+
+   **answer**: use phased GitHub Actions rather than starting with deployment only. The first minimum setup should be no-deploy CI so the split-repo build can be proven before production deployment changes. Phase 1 adds app CI in `mylifeindigital`; it runs on application PRs, checks out the application repo plus the selected/default content repo ref, sets `CONTENT_DIR`, generates `posts-data.ts`, and runs the web build/typecheck without deploying. Phase 2 adds content CI in `mylifeindigital.content`; it runs on content PRs and validates that Markdown content can be processed by the application build pipeline without deploying. Phase 3 adds production deploy in the application repo, and only this workflow should run `wrangler deploy`.
+
+10. **When exactly is Cloudflare native deployment disabled?**
+   Before Actions exists, after first successful Actions deploy, or after a short parallel validation period? I recommend after one verified Actions deploy.
+
+   **answer**: Cloudflare native deployment is currently triggered by changes to the application `main` branch, so the phased GitHub Actions implementation should avoid enabling a second automatic production path too early. No-deploy app/content CI can be added while Cloudflare remains active. The GitHub Actions deploy workflow should first be introduced in explicit manual-dispatch mode and verified with explicit application and content refs. After that, disable or constrain Cloudflare native Git deployment, then enable GitHub Actions as the single automatic production deployment path.
+
+11. **Do you want a manual approval step for production deploys?**
+   GitHub Environments can require approval, but for a single-author project it may be extra friction. Maybe use manual approval only for manual recovery deploys or while stabilizing.
+
+   **answer**: skip manual approval gates for the initial workflow. This is a single-author project, and approval gates would add operational overhead without solving the main migration risk. Manual dispatch with explicit refs can still be used for cutover, recovery, or controlled redeployment, but that is different from requiring a separate approval step before production deployment.
+
+12. **What counts as rollback success?**
+   Is rollback “redeploy known-good app/content SHAs,” or does it also require reverting content `main` afterward? I’d separate deploy rollback from source correction.
+
+   **answer**: separate deployment rollback from source correction.
+
+   Deployment rollback means restoring production by redeploying a known-good application SHA and content SHA through the application repository deployment workflow. This is relevant when the deployed Worker is broken, content rendering fails, generated `posts-data.ts` is bad, a build/pipeline change causes production issues, or a newly published content commit creates a visible problem that needs to be removed from production quickly.
+
+   Source correction means fixing repository history after production has been stabilized. For content issues, create a new content branch and PR that reverts or corrects the Markdown. For application issues, create an application branch and PR that reverts or fixes the code/build change.
+
+   Rollback success is reached when production is back on a known-good app/content pair and the deployed state is recorded. The source correction can follow as a separate step unless the rollback itself already deployed the desired source state.
+
+   Automated checks should prevent known structural failures before deployment, but rollback remains necessary for issues that are semantic, visual, environment-specific, or only noticed after production verification.
+
+13. **Should tests be a blocker before deploy?**
+   Yes, once they exist. Initially: build/typecheck/content validation should block. Later tests can become required checks.
+
+   **answer**: tests should be introduced going forward, but they should not be treated as the primary deployment blocker until there is sufficient useful coverage. For the initial migration, required blockers should be dependency install, cross-repository checkout, `CONTENT_DIR`, `build-posts.ts`, generated `posts-data.ts`, content validation, and the web build/typecheck. Once tests exist and cover meaningful risk, they can be promoted into required CI checks before production deployment.
+
+14. **Can the cutover become follow-up CRs?**
+   Yes. Likely:
+   - [CR-020](../../change-requests/CR-020-create-content-repository-and-migrate-files.md) create content repo and migrate files
+   - [CR-021](../../change-requests/CR-021-add-content-dir-support-to-content-tooling.md) add `CONTENT_DIR` support to build/new-content scripts
+   - [CR-022](../../change-requests/CR-022-update-readme-workspace-and-local-docs.md) update README/workspace/local docs
+   - [CR-023](../../change-requests/CR-023-establish-baseline-test-setup.md) establish baseline test setup
+   - [CR-019](../../change-requests/CR-019-implement-split-repository-github-actions-ci-cd.md) handles GitHub Actions
+   - [CR-018](../../change-requests/CR-018-decide-web-admin-role-after-content-repository-split.md) handles web admin role
+   - [CR-014](../../change-requests/CR-014-reassess-generated-content-artifact-strategy.md) handles generated artifacts
+
+Also, to your inline question: **not all source files in `web/` are “deployed” as files**. Wrangler bundles the Worker entry and reachable imports into a Worker artifact, and static assets come from `web/public` via the assets config. Build scripts like `web/scripts/build-posts.ts` run at build time; they are not runtime routes unless imported by the Worker.

--- a/docs/raw/story-crafter-prompt.md
+++ b/docs/raw/story-crafter-prompt.md
@@ -1,0 +1,47 @@
+You are a children’s story studio helping me create a richer ongoing series of bedtime or read-aloud stories for my son.
+
+The goal is to avoid formulaic stories by using a multi-pass creative process: one role drafts the story, one or more reviewer roles critique it, and a final editor revises it into a polished version. The stories should feel imaginative, warm, age-appropriate, and emotionally meaningful, while also building continuity across episodes.
+
+Before creating any story, ask me for:
+- The broad setting or theme, such as Africa, woodland, ocean, space, farm, city, or another world
+- The main characters I want included
+- My son’s age or reading level
+- The target reading time
+- The value or life lesson for this story, if I already have one in mind
+- Any previous story context, recurring details, character relationships, unresolved threads, or series canon I want preserved
+
+Once I answer, run the story through this workflow:
+
+1. **Series Keeper**
+   Identify continuity opportunities before drafting. Track recurring characters, relationships, emotional growth, unresolved promises, places, rituals, objects, and small details that can make the series feel connected across stories. If no prior context exists, establish a few gentle continuity seeds that could matter later.
+
+2. **Story Architect**
+   Design the story structure before writing. Create a beginning, a clear desire or problem, rising complication, meaningful choice, consequence, resolution, and quiet emotional landing. Avoid repeating a predictable formula from previous stories. Make sure the lesson emerges from the events rather than being preached.
+
+3. **Draft Writer**
+   Write the first full story in lyrical, clear prose suitable for being read aloud. Use vivid concrete details, dialogue, humor, and emotional stakes. Keep the vocabulary appropriate for the child’s age while still making the story enjoyable for an adult reader.
+
+4. **Reviewer One: Child Engagement**
+   Review the draft for wonder, pacing, humor, sensory detail, memorable moments, and whether a child would want to hear what happens next. Suggest specific improvements.
+
+5. **Reviewer Two: Values and Emotional Truth**
+   Review whether the story teaches the intended value honestly and gently. Check that characters make understandable mistakes, learn through experience, and are not shamed. Suggest specific improvements.
+
+6. **Reviewer Three: Continuity and Series Depth**
+   Review how well the story connects to previous or future stories. Look for chances to deepen relationships, reuse meaningful objects or places, plant a future thread, or show character growth across episodes. Suggest specific improvements.
+
+7. **Final Editor**
+   Revise the story using the reviewers’ strongest suggestions. Preserve warmth and readability. Do not include the internal review notes unless I specifically ask for them. Deliver only the final polished story, followed by a brief “Series Notes” section listing continuity details introduced or advanced.
+
+Use this style:
+- Warm, imaginative, and emotionally grounded
+- Suitable for reading aloud
+- Gentle humor, but not silly for its own sake
+- A clear moral lesson carried by the story’s events
+- Recurring details that reward repeated reading
+- No heavy-handed explanation at the end
+- No generic fairy-tale autopilot
+
+When you are ready, ask me for the story inputs.
+
+Think before answering (take time to reason through this carefully).

--- a/docs/raw/story-crafter-sample1.md
+++ b/docs/raw/story-crafter-sample1.md
@@ -1,0 +1,517 @@
+## **The Friend Who Would Not Say Much**
+
+Beside the quiet green meadow stood the young Acorn Tree.
+
+His branches stretched wide over the grass, his leaves shimmered softly in the morning light, and his roots curled gently near the path that led to the pond.
+
+Every day, Squirrel, Robin, Wagtail, Frog, and Mouse met beneath him.
+
+Robin brought songs.
+
+Wagtail brought cheerful hops.
+
+Frog brought calm thoughts.
+
+Mouse brought tiny treasures.
+
+And Squirrel brought words.
+
+Many words.
+
+Words about acorns.
+
+Words about weather.
+
+Words about plans.
+
+Words about why his latest idea was probably brilliant.
+
+One morning, Squirrel came racing down the Acorn Tree’s trunk.
+
+“Friends! I have invented a new game!”
+
+Robin fluttered down from a branch.
+
+“What kind of game?”
+
+“A fast game,” said Squirrel.
+
+Wagtail’s tail bobbed.
+
+“I like fast games.”
+
+Mouse peeked out from between the roots.
+
+“How fast?”
+
+“Very fast,” said Squirrel. “Possibly too fast, which is how you know it is exciting.”
+
+Frog blinked slowly from beside the pond.
+
+“That is not usually how safety works.”
+
+Squirrel ignored this and began explaining.
+
+“The game is called Acorn Dash. First, we place an acorn on the white stone. Then we run around the pond, hop over the twig, touch the yellow flower, and return before Robin sings three notes.”
+
+Robin tilted his head.
+
+“That is oddly specific.”
+
+“It is a well-designed game,” said Squirrel.
+
+Wagtail hopped in a circle.
+
+“Let’s play!”
+
+Mouse looked down at her tiny paws.
+
+“That sounds… difficult.”
+
+Squirrel waved a paw.
+
+“You will be fine. Everyone will be fine. It is easy.”
+
+Mouse opened her mouth, then closed it.
+
+Frog noticed.
+
+The Acorn Tree noticed too.
+
+But Squirrel was already rolling the first acorn to the white stone.
+
+“Ready?” cried Squirrel.
+
+Robin sang one note.
+
+Squirrel dashed forward.
+
+Wagtail hopped after him.
+
+Robin flew above them.
+
+Frog watched from the pond.
+
+Mouse ran as fast as she could, but the grass was tall, the twig was big, and the yellow flower seemed very far away.
+
+By the time Squirrel had finished, Wagtail had finished, and Robin had sung three bright notes, Mouse was still halfway through the grass.
+
+Squirrel bounced excitedly.
+
+“That was excellent! Again?”
+
+Mouse panted softly.
+
+“I… maybe…”
+
+“Wonderful!” said Squirrel. “Second round!”
+
+Frog blinked.
+
+“She did not say yes.”
+
+Squirrel stopped.
+
+“She said maybe.”
+
+“Maybe is not yes,” said Frog.
+
+Mouse looked embarrassed.
+
+“It is all right.”
+
+The Acorn Tree’s leaves rustled gently.
+
+“Is it?”
+
+Mouse looked up at the tree.
+
+Then down at the grass.
+
+“I do not want to spoil the game.”
+
+Wagtail hopped closer.
+
+“You are not spoiling anything.”
+
+Squirrel tilted his head.
+
+“But you like games, don’t you?”
+
+Mouse nodded.
+
+“Yes. But this one is very fast. The grass is high for me. And when everyone rushes ahead, I feel… left behind.”
+
+The meadow became quiet.
+
+Squirrel’s ears drooped.
+
+“Oh.”
+
+Robin landed on a low branch.
+
+“I did not notice.”
+
+“I did,” said Frog.
+
+Squirrel looked at him.
+
+“Why didn’t you say something?”
+
+Frog blinked.
+
+“I was listening first.”
+
+Squirrel frowned.
+
+“Listening first?”
+
+The Acorn Tree lowered a gentle branch.
+
+“Listening means more than waiting for your turn to speak. It means making room for someone else’s experience.”
+
+Squirrel rubbed his paws together.
+
+“I thought listening meant keeping my mouth closed.”
+
+“That helps,” said Robin.
+
+“A lot,” said Frog.
+
+Squirrel gave him a look.
+
+Frog blinked innocently.
+
+The Acorn Tree continued, “But true listening also means noticing what is not being said loudly.”
+
+Squirrel looked at Mouse.
+
+Mouse’s whiskers were still trembling from the race.
+
+“I did not listen,” said Squirrel softly. “I was too busy explaining my brilliant game.”
+
+“It was a good idea,” said Mouse kindly.
+
+“But not good for everyone,” said Wagtail.
+
+Squirrel nodded slowly.
+
+“That matters.”
+
+He sat down beside Mouse.
+
+“What kind of game would feel better?”
+
+Mouse looked surprised.
+
+“You want me to choose?”
+
+“Yes,” said Squirrel. “And I will try very hard not to interrupt.”
+
+Robin smiled.
+
+Wagtail sat down too.
+
+Frog climbed from his pond stone and settled nearby.
+
+Mouse thought for a moment.
+
+“I like treasure games,” she said. “Small things hidden in the grass. Seeds, feathers, smooth pebbles. Things you must notice carefully.”
+
+Squirrel’s eyes brightened.
+
+“I am excellent at finding—”
+
+He stopped himself.
+
+Mouse smiled.
+
+“You may speak.”
+
+Squirrel took a breath.
+
+“I was going to say I am excellent at finding things. But maybe I should ask how your game works first.”
+
+Frog nodded.
+
+“A rare and promising moment.”
+
+Mouse stood a little taller.
+
+“We each find one small treasure. Not the biggest. Not the fastest. The most interesting. Then we tell why we chose it.”
+
+Robin fluttered happily.
+
+“That sounds lovely.”
+
+Wagtail bobbed her tail.
+
+“And thoughtful.”
+
+Squirrel looked uncertain.
+
+“So nobody wins?”
+
+Mouse shook her head.
+
+“Everyone notices.”
+
+Squirrel considered this.
+
+“That is very different from winning.”
+
+“Yes,” said Mouse.
+
+“Possibly suspicious.”
+
+“Squirrel,” said Wagtail.
+
+“I said possibly.”
+
+They began Mouse’s game.
+
+Robin flew low and found a tiny blue feather caught in the grass.
+
+Wagtail found a smooth white pebble shaped almost like an egg.
+
+Frog found a curled brown leaf floating at the edge of the pond.
+
+Mouse found a tiny seed with a striped shell.
+
+Squirrel raced off at first, ready to find the most magnificent treasure.
+
+Then he stopped.
+
+Mouse had said interesting, not biggest.
+
+So he slowed down.
+
+He looked beneath leaves.
+
+He peered around roots.
+
+He listened to the grass moving in the breeze.
+
+At last, near the Acorn Tree’s roots, he found a very small acorn cap.
+
+It was not shiny.
+
+It was not large.
+
+It was not impressive in the usual squirrel way.
+
+But it looked like a tiny bowl.
+
+Squirrel carried it back carefully.
+
+The friends gathered beneath the tree.
+
+Robin showed his feather.
+
+“I chose this because it reminds me that soft things can still travel far.”
+
+Wagtail showed her pebble.
+
+“I chose this because it is smooth from being touched by rain and soil.”
+
+Frog placed down his curled leaf.
+
+“I chose this because it floated without rushing.”
+
+Squirrel whispered, “Of course you did.”
+
+Frog looked pleased.
+
+Mouse held up her striped seed.
+
+“I chose this because it is small, but something could grow inside it.”
+
+Everyone smiled.
+
+Then it was Squirrel’s turn.
+
+He placed the acorn cap in the middle.
+
+“I chose this because…” He paused.
+
+Usually, Squirrel enjoyed talking.
+
+But now he wanted to choose the right words.
+
+Not the most words.
+
+The right ones.
+
+“I chose it because it reminded me of Mouse’s game,” he said. “Small, but worth noticing.”
+
+Mouse’s eyes warmed.
+
+“Thank you.”
+
+Squirrel looked at her.
+
+“And I am sorry I rushed ahead earlier.”
+
+Mouse nodded.
+
+“Thank you for listening.”
+
+Squirrel smiled.
+
+“It was difficult.”
+
+Robin laughed.
+
+Squirrel added quickly, “But good.”
+
+Later that afternoon, Squirrel wanted to improve Mouse’s game.
+
+He had ideas.
+
+Many ideas.
+
+Treasure towers.
+
+Timed treasure hunts.
+
+A scoring system involving acorn caps.
+
+Possibly uniforms.
+
+He opened his mouth.
+
+Then he looked at Mouse.
+
+“Would you like ideas for another version of the game,” he asked, “or would you like us to keep playing it your way?”
+
+Mouse thought about it.
+
+“My way for now.”
+
+Squirrel nodded.
+
+His tail twitched.
+
+His mouth nearly exploded with unsaid suggestions.
+
+But he nodded.
+
+“All right.”
+
+Frog blinked slowly.
+
+“That was listening with effort.”
+
+“Enormous effort,” said Squirrel.
+
+The Acorn Tree rustled warmly.
+
+“And that effort is love in action.”
+
+As the sun began to sink, the friends sat beneath the branches.
+
+They placed all their tiny treasures in a small circle near the roots.
+
+The feather.
+
+The pebble.
+
+The curled leaf.
+
+The striped seed.
+
+The acorn cap.
+
+Nothing grand.
+
+Nothing loud.
+
+Nothing that needed to win.
+
+But together, they made something beautiful.
+
+Squirrel looked at Mouse.
+
+“I did not know you felt left behind in fast games.”
+
+Mouse looked down.
+
+“I did not know how to say it.”
+
+“I should have noticed,” said Squirrel.
+
+“Maybe,” said Mouse. “But you listened when I did say it.”
+
+Robin nodded.
+
+“That matters.”
+
+Wagtail smiled.
+
+“Sometimes friends need to slow down so everyone can belong.”
+
+Frog looked at the pond.
+
+“And sometimes the quietest voice is the one most worth hearing.”
+
+The Acorn Tree’s leaves whispered in the evening breeze.
+
+“What did you learn today, little one?”
+
+Squirrel thought carefully.
+
+“I learned that listening is not just being quiet.”
+
+The Acorn Tree waited.
+
+“It is paying attention.”
+
+Robin smiled.
+
+“And?”
+
+“It is asking before deciding.”
+
+Wagtail nodded.
+
+“And?”
+
+“It is caring about how someone else experiences the game, not only whether I am enjoying it.”
+
+Mouse smiled.
+
+“And?”
+
+Squirrel looked at the tiny acorn cap.
+
+“It is making space for small voices.”
+
+The Acorn Tree rustled softly.
+
+“That is listening.”
+
+That evening, Robin sang a gentle song.
+
+Wagtail danced in smaller, slower steps so Mouse could join.
+
+Frog sat beside the pond, looking peaceful.
+
+Mouse placed her striped seed safely between the roots.
+
+And Squirrel sat quietly for a while.
+
+Not because he had nothing to say.
+
+He had plenty.
+
+He always had plenty.
+
+But he had learned that sometimes friendship grows best in the quiet space where another friend finally feels heard.
+
+Beneath the young Acorn Tree, the friends rested together.
+
+And for once, Squirrel did not fill the whole meadow with words.
+
+He listened.
+
+And the meadow had much to say.

--- a/docs/raw/story-crafter-sample2.md
+++ b/docs/raw/story-crafter-sample2.md
@@ -1,0 +1,591 @@
+## **The Gift Squirrel Did Not Keep**
+
+Beside the quiet green meadow stood the young Acorn Tree.
+
+His branches stretched wide over the grass, his leaves shimmered in the morning light, and his roots curled gently near the path that led to the pond.
+
+Every day, Squirrel, Robin, Wagtail, Frog, and Mouse met beneath him.
+
+Robin brought songs.
+
+Wagtail brought cheerful hops.
+
+Frog brought calm thoughts.
+
+Mouse brought tiny treasures from the grass.
+
+And Squirrel brought acorns.
+
+Sometimes he shared them.
+
+Sometimes he counted them.
+
+Sometimes he counted them while pretending he was sharing them.
+
+One crisp morning, Squirrel came racing down the Acorn Tree’s trunk with a bright smile and a small bundle wrapped in leaves.
+
+“Friends,” he announced, “I have found something wonderful.”
+
+Robin fluttered down from a branch.
+
+“Is it an acorn?”
+
+Squirrel looked offended.
+
+“Not everything wonderful is an acorn.”
+
+Frog blinked from beside the pond.
+
+“Is it two acorns?”
+
+Squirrel paused.
+
+“No.”
+
+Wagtail hopped closer.
+
+“What is it?”
+
+Squirrel carefully opened the leaves.
+
+Inside was a soft patch of golden moss.
+
+It looked warm and springy, like a tiny meadow cloud.
+
+Mouse’s eyes widened.
+
+“Oh, that is beautiful.”
+
+“I found it near the old stump,” said Squirrel proudly. “It will make my winter nest the softest nest in the meadow.”
+
+Robin nodded.
+
+“It does look very comfortable.”
+
+Squirrel hugged the moss to his chest.
+
+“Exactly. My nest shall be magnificent.”
+
+Just then, a cold wind blew across the meadow.
+
+Whoooosh.
+
+The Acorn Tree’s leaves trembled.
+
+Mouse shivered.
+
+Wagtail tucked one foot beneath her.
+
+Frog blinked slowly.
+
+“The air has become rude.”
+
+Mouse sneezed.
+
+“Achoo.”
+
+Squirrel looked at her.
+
+“Are you cold?”
+
+Mouse nodded.
+
+“A little. My nest is safe, but the floor is hard. I used the last soft grass yesterday to patch the doorway.”
+
+Squirrel looked down at the golden moss.
+
+Then at Mouse.
+
+Then back at the moss.
+
+It was very soft.
+
+Very golden.
+
+Very much meant for his nest.
+
+Robin noticed his face.
+
+“Squirrel?”
+
+Squirrel quickly wrapped the moss again.
+
+“Yes?”
+
+Wagtail tilted her head.
+
+“You are holding it very tightly.”
+
+“It is valuable,” said Squirrel.
+
+Mouse gave a small smile.
+
+“I am glad you found it. Your nest will be warm.”
+
+That made Squirrel feel worse.
+
+If Mouse had demanded it, he might have said no.
+
+If she had grabbed it, he would have grabbed it back.
+
+But she had simply been happy for him.
+
+That was inconvenient.
+
+The Acorn Tree rustled gently.
+
+“Generosity often begins when we notice that something we have could help someone else.”
+
+Squirrel frowned.
+
+“Does generosity always involve giving away things one was planning to keep?”
+
+“Not always,” said the Acorn Tree.
+
+Squirrel relaxed.
+
+“But often,” added Frog.
+
+Squirrel gave Frog a look.
+
+“You waited to say that.”
+
+“Yes,” said Frog.
+
+Squirrel looked again at Mouse.
+
+She was rubbing her tiny paws together for warmth.
+
+He sighed.
+
+A long, tragic, deeply squirrelly sigh.
+
+“Mouse?”
+
+Mouse looked up.
+
+“Yes?”
+
+Squirrel held out the golden moss.
+
+“You can have this.”
+
+Mouse blinked.
+
+“But it is for your winter nest.”
+
+“I know.”
+
+“And you were excited about it.”
+
+“I know.”
+
+“And it is very soft.”
+
+“I know, Mouse. Please take it before I begin describing it and change my mind.”
+
+Mouse stepped forward carefully.
+
+“Are you sure?”
+
+Squirrel swallowed.
+
+“Yes.”
+
+Mouse took the moss and held it close.
+
+Her face brightened.
+
+“Thank you, Squirrel.”
+
+Squirrel tried to shrug as if it did not matter.
+
+“It is only moss.”
+
+Robin smiled.
+
+“It did matter.”
+
+Wagtail nodded.
+
+“That is what made it generous.”
+
+Frog blinked.
+
+“Giving away something you do not care about is easy. Giving something you wanted is harder.”
+
+Squirrel looked at his empty paws.
+
+“Harder is correct.”
+
+Mouse hurried to her little nest between the roots and tucked the golden moss inside. The nest looked warmer at once.
+
+Squirrel watched quietly.
+
+He felt glad.
+
+And also a little sad.
+
+Both feelings sat inside him at the same time, which was crowded.
+
+Later that morning, Robin flew down with a bright red berry in his beak.
+
+“I found this near the hedge,” he said. “It is the last ripe berry on the bush.”
+
+Squirrel’s ears perked up.
+
+“A berry?”
+
+Robin placed it on a flat stone.
+
+“I was going to eat it after my song.”
+
+Wagtail looked at the berry.
+
+“It looks delicious.”
+
+Mouse peeked from her warmer nest.
+
+“It smells sweet.”
+
+Frog climbed closer.
+
+“I do not usually eat berries, but I respect its roundness.”
+
+Robin looked at the berry.
+
+Then at his friends.
+
+Then at the berry again.
+
+Squirrel watched him carefully.
+
+Robin took a breath.
+
+“Would anyone like to share it?”
+
+Squirrel gasped.
+
+“The whole berry?”
+
+Robin smiled.
+
+“It is not very large, but yes. We can divide it.”
+
+Wagtail’s eyes lit up.
+
+“That is generous.”
+
+Robin shrugged.
+
+“Squirrel gave away his moss. It made me think.”
+
+Squirrel stood a little taller.
+
+“My moss has inspired berry kindness.”
+
+They divided the berry into tiny pieces.
+
+Robin took one.
+
+Wagtail took one.
+
+Mouse took one.
+
+Squirrel took one.
+
+Frog accepted the smallest piece, tasted it, and said, “Interesting. Wet sunshine.”
+
+Everyone agreed this was probably a compliment.
+
+After the berry, Wagtail found a smooth white feather near the pond.
+
+“Oh,” she said. “This would look lovely beside my hopping path.”
+
+She carried it proudly for a while.
+
+Then she noticed Robin trying to patch a thin place in his nest.
+
+The wind had loosened some of the lining.
+
+Wagtail looked at the feather.
+
+Then at Robin’s nest.
+
+Then back at the feather.
+
+She sighed.
+
+“Robin?”
+
+Robin looked down.
+
+“Yes?”
+
+“You may use this feather for your nest.”
+
+Robin’s eyes softened.
+
+“But you just found it.”
+
+“I know,” said Wagtail. “I wanted to keep it. But your nest needs it more than my path does.”
+
+Robin accepted it gently.
+
+“Thank you.”
+
+Squirrel watched with wide eyes.
+
+“This generosity thing is spreading.”
+
+Frog nodded.
+
+“Like pond ripples.”
+
+Squirrel looked at Frog.
+
+“Are you going to give something next?”
+
+Frog sat very still.
+
+“I am considering.”
+
+Everyone waited.
+
+Frog continued sitting.
+
+Squirrel whispered, “This may take a while.”
+
+At last, Frog climbed down from his favourite smooth stone beside the pond.
+
+He looked at it thoughtfully.
+
+“This stone is warm in the afternoon and flat in the middle. It is my best thinking stone.”
+
+“We know,” said Wagtail.
+
+“You tell us often,” said Squirrel.
+
+Frog nodded.
+
+“Good. Then you understand its importance.”
+
+Just then, Mouse came out of her nest and looked toward the pond.
+
+“The sun reaches that stone nicely,” she said. “My paws are still cold.”
+
+Frog looked at Mouse.
+
+Then at the stone.
+
+Then at the pond.
+
+“This stone is available,” he said.
+
+Mouse blinked.
+
+“For me?”
+
+“For today,” said Frog. “Perhaps longer. We shall negotiate like gentle creatures.”
+
+Mouse climbed onto the stone and stretched her paws in the sun.
+
+“Oh, it is warm.”
+
+Frog sat beside the pond on a smaller, bumpier stone.
+
+Squirrel tilted his head.
+
+“Is that stone comfortable?”
+
+“No,” said Frog.
+
+“Do you regret your generosity?”
+
+Frog blinked.
+
+“Not yet. Ask me after sunset.”
+
+The friends laughed.
+
+By afternoon, the meadow felt different.
+
+Not because everyone had given everything away.
+
+They had not.
+
+Squirrel still had acorns.
+
+Robin still had songs.
+
+Wagtail still had her hopping path.
+
+Frog still had many opinions about stones.
+
+Mouse still had her tiny treasures.
+
+But each friend had noticed someone else’s need and opened their paws, wings, feet, or favourite sitting place.
+
+The Acorn Tree watched them with warm, rustling leaves.
+
+Then the wind grew stronger.
+
+It swept through the meadow and tugged at the Acorn Tree’s branches.
+
+A cluster of dry leaves broke loose and scattered across the grass.
+
+Squirrel jumped up.
+
+“Leaves!”
+
+He raced after them, gathering the best ones.
+
+One leaf was broad and dry.
+
+One was curled like a little cup.
+
+One was soft and golden.
+
+He stacked them in a pile.
+
+“These will be excellent for my nest.”
+
+Mouse looked out from her mossy doorway.
+
+“Those are good leaves.”
+
+Robin flew down.
+
+“They could also help cover the thin side of Mouse’s nest.”
+
+Squirrel looked at Mouse’s nest.
+
+The golden moss made the floor soft, but one side of the doorway still let in wind.
+
+Squirrel looked at his leaves.
+
+Again.
+
+This was becoming a pattern.
+
+“Generosity is very persistent,” he muttered.
+
+The Acorn Tree chuckled.
+
+Squirrel carried the leaves to Mouse’s doorway.
+
+“Here. These can block the wind.”
+
+Mouse looked surprised.
+
+“You have already given me the moss.”
+
+“Yes,” said Squirrel. “And now I am apparently in the leaf business.”
+
+Wagtail helped tuck the leaves into place.
+
+Robin pressed the feather lining into his own nest.
+
+Frog let Mouse stay on the warm stone until her paws were no longer cold.
+
+By evening, the meadow glowed softly in the golden light.
+
+Mouse’s nest was warm.
+
+Robin’s nest was stronger.
+
+Wagtail’s hopping path was plain but cheerful.
+
+Frog had returned to his favourite stone, after Mouse declared her paws fully restored.
+
+Squirrel climbed into his own winter nest.
+
+It was not as soft as he had imagined that morning.
+
+There was no golden moss.
+
+Fewer perfect leaves.
+
+No grand nest improvement worthy of applause.
+
+But then Mouse called from below.
+
+“Squirrel?”
+
+“Yes?”
+
+“Thank you again. I am warm now.”
+
+Robin called from his branch.
+
+“And thank you for showing us how to begin.”
+
+Wagtail smiled.
+
+“Yes. One generous choice helped everyone make another.”
+
+Frog blinked sleepily.
+
+“Your missing moss improved the whole meadow.”
+
+Squirrel looked around.
+
+Mouse was warm.
+
+Robin was safe.
+
+Wagtail looked happy.
+
+Frog was back on his stone.
+
+The Acorn Tree’s roots sheltered them all.
+
+Squirrel’s own nest was a little less soft.
+
+But his heart felt oddly fuller.
+
+The Acorn Tree rustled above him.
+
+“What did you learn today, little one?”
+
+Squirrel thought carefully.
+
+“I learned that generosity is not giving because you have too much.”
+
+Robin nodded.
+
+“And?”
+
+“It is giving because someone else has too little.”
+
+Wagtail smiled.
+
+“And?”
+
+Squirrel looked at Mouse’s warm doorway.
+
+“It can feel hard at first.”
+
+Frog added, “Sometimes very hard.”
+
+Squirrel nodded.
+
+“But afterward, the meadow feels warmer.”
+
+The Acorn Tree’s leaves whispered in the evening breeze.
+
+“That is generosity.”
+
+Squirrel curled into his nest.
+
+It was not the softest nest in the meadow.
+
+But he did not mind as much now.
+
+Because generosity had done something strange and wonderful.
+
+It had taken one small piece of golden moss and turned it into warmth, kindness, sharing, and friendship.
+
+And beneath the young Acorn Tree, the friends rested together, knowing that a gift given with love does not truly leave you empty.
+
+Sometimes, it makes room for something better to grow.

--- a/docs/raw/story-crafter.md
+++ b/docs/raw/story-crafter.md
@@ -1,0 +1,15 @@
+# Story Crafter
+
+I have written stories for my son's bedtime reading for several evenings. Sample story can be found in [story crafter sample1](./story-crafter-sample1.md) and [story crafter sample 2](./story-crafter-sample2.md). I also used the prompt-optimizer skill to generate [story crafter prompt](./story-crafter-prompt.md). 
+
+Idea: create a standalone feature area on the website showcasing a series of generated stories featuring character combinations provided.  
+
+Ideas:
+
+- Create a section where stories can live? the purpose of mylifeindigital has and will always be to showcase ideas and thinking. Story Crafter is one such idea.
+- The content workflow is not clear yet. But I would imagine:
+    - create a series such as the acorn tree series. a series would cover a selection of characters (acorn tree, squirrel, frog, mouse, wagtail and a robin), a setting such as a meadow with an acorn tree and a pond, a series of topics such as trust, humility.
+    - generate the output
+    - unclear workflow. it would be convenient if the story was delivered on my mobile phone in a an easy to read format. 
+
+**important** this is not to be considered part of the current CR-017 change request. it must come after the current CR's are completed first. do not bloat CR-017 any further. 

--- a/docs/wiki/concepts/git-backed-content.md
+++ b/docs/wiki/concepts/git-backed-content.md
@@ -14,19 +14,24 @@ The project treats Markdown in Git as the canonical content store. Authoring too
 - Cloudflare Workers cannot rely on runtime filesystem access.
 - Content must be compiled or otherwise made available during deployment.
 - App-driven commits can create repository sync friction when code and content share one repo.
-- Any future repository split should be a deliberate architectural decision.
+- Application and content commits become separate deployment inputs after the repository split.
 
-## Current Bias
+## Current Decision
 
-Stay with a single Git repository for now, but make repository boundaries an explicit design concern as content workflows mature.
+Publishable Markdown content should move to a separate Git repository, likely `mylifeindigital.content`. Application code, build tooling, change requests, docs/wiki knowledge, and experiments remain in `mylifeindigital`.
+
+Both repositories use short-lived branches. Application branches map to change requests; content branches map to content items or closely related content changes. The `draft` frontmatter flag remains a publish safeguard but does not replace branch isolation.
 
 ## Related Pages
 
 - [Content Operations App](../projects/content-operations-app.md)
 - [Content Pipeline](../projects/content-pipeline.md)
 - [Authoring Surface](../decisions/authoring-surface.md)
+- [Branching Workflow](../decisions/branching-workflow.md)
 
 ## Sources
 
 - [90-day-plan.md](../../raw/90-day-plan.md)
 - [scaling-content-options.md](../../raw/scaling-content-options.md)
+- [branching-workflows.md](../../raw/branching-workflows.md)
+- [CR-007: Decide Single Repo vs Split Content Repository](../../../change-requests/CR-007-decide-single-repo-vs-split-content-repository.md)

--- a/docs/wiki/decisions/authoring-surface.md
+++ b/docs/wiki/decisions/authoring-surface.md
@@ -4,20 +4,26 @@ The authoring surface should remain replaceable. The project should not define i
 
 ## Current Decision
 
-Continue with browser-based content management as a valid near-term path, while keeping content logic independent enough to support other surfaces later.
+Use VS Code as the default near-term Markdown editor and source-code workspace.
+
+The intended future content authoring surface is a focused Electron app for creating, processing, organizing, and publishing content. The Electron app should operate on content rather than becoming an environment for editing or running the application source code.
+
+Authoring logic should remain independent enough to support terminal, script-based, or other future surfaces where useful.
 
 ## Rationale
 
-- Browser authoring aligns with the existing admin/dashboard direction.
-- A terminal or TUI flow may better support focused writing for the primary user.
-- A lightweight desktop app, such as Tauri, may eventually fit content operations.
+- VS Code is already an effective Markdown editor and remains useful for viewing and editing source code.
+- Electron can provide a focused content workflow while retaining access to local repositories, scripts, and desktop resources.
+- Keeping application-code work in VS Code gives the Electron app a narrower, clearer responsibility.
+- Terminal and script-based flows remain useful for automation, recovery, and agent-assisted work.
 - Shared content-core logic should matter more than the UI shell.
 
 ## Constraints
 
 - The authoring surface must preserve Markdown in Git as the source of truth.
 - Preview, validation, and publishing logic should not be trapped inside one UI.
-- Monaco is acceptable for now but should remain an implementation detail.
+- The Electron app should focus on content authoring and operations, not source-code development.
+- VS Code should remain usable even after the Electron app becomes the preferred content surface.
 
 ## Related Pages
 
@@ -29,5 +35,6 @@ Continue with browser-based content management as a valid near-term path, while 
 
 - [90-day-plan.md](../../raw/90-day-plan.md)
 - [editor-design.md](../../raw/editor-design.md)
+- [content-authoring.md](../../raw/content-authoring.md)
 - [CR-005: Decide Electron vs Tauri for Content Operations App](../../../change-requests/CR-005-decide-electron-vs-tauri-for-content-operations-app.md)
 - [CR-006: Define Content Operations App Scope and Workflows](../../../change-requests/CR-006-define-content-operations-app-scope-and-workflows.md)

--- a/docs/wiki/decisions/branching-workflow.md
+++ b/docs/wiki/decisions/branching-workflow.md
@@ -1,0 +1,76 @@
+# Branching Workflow
+
+The application repository and content repository should both use short-lived branches, but the branch unit differs by repository.
+
+## Application Repository
+
+- Start active change-request work from an up-to-date `main` branch.
+- Create one branch per CR, using a scoped name such as `codex/cr-007-content-repository-split` for agent-created branches.
+- Keep the CR document, implementation notes, code, tests, and related docs together on that branch.
+- Merge through a pull request after relevant checks pass.
+- Close the pull request and delete the branch if the CR is abandoned; do not place in-progress CR work directly on `main`.
+
+Hosted environments for every CR branch are not required. Local validation and CI checks are sufficient unless preview environments become valuable enough to justify their operational overhead.
+
+## Content Repository
+
+- Start content work from an up-to-date content `main` branch.
+- Create a short-lived branch for a new content item, revision, or small group of closely related content changes.
+- Use a content-scoped name such as `content/post-slug`.
+- Generate new content with `draft: true`, then edit, commit, and validate it on the content branch.
+- Preview content locally against the application pipeline.
+- Set `draft: false` when the content is publish-ready.
+- Merge through a pull request after validation; merging content `main` may trigger the production web build.
+- Delete the content branch after merge.
+
+The `draft` flag remains a publication safeguard, but it does not replace branch isolation. Content branches prevent unfinished or unrelated writing changes from accumulating on production-linked `main`.
+
+## Cross-Repository Changes
+
+When one outcome requires coordinated application and content changes:
+
+- use a CR branch in the application repository;
+- use a content branch in the content repository;
+- record the paired refs in the CR or pull-request descriptions;
+- validate the selected application and content refs together locally or in CI;
+- merge in an order that keeps production compatible.
+
+## Sync Rules
+
+- Pull or fetch the latest `main` before creating a branch.
+- Keep application and content Git state separate, even when both repositories are open in one VS Code workspace.
+- Do not let generated content files in the application repository become the source of truth for content changes.
+- Protect `main` in both repositories before production deployment is automated through GitHub Actions.
+
+## Protecting Main Branches
+
+Protect `main` in both the application and content repositories before enabling GitHub Actions production deployment.
+
+Baseline protection should:
+
+- require changes to reach `main` through a pull request;
+- require relevant CI checks to pass before merge;
+- block force pushes and branch deletion;
+- require review conversations to be resolved;
+- avoid requiring another person's approval initially because this is a single-author project;
+- allow administrative bypass only for recovery, not routine work.
+
+GitHub Actions should separate validation from production deployment:
+
+- pull requests run build-only validation and do not deploy;
+- application `main` merges validate the selected application and content commits, then deploy their combined Worker bundle;
+- content `main` merges trigger the same production deployment workflow because content must be compiled into `web/src/utils/posts-data.ts`;
+- only one workflow should own production deployment to avoid duplicate or competing deployments.
+
+The repositories have separate change histories, but deployment combines a specific application commit and content commit into one Worker artifact.
+
+## Related Pages
+
+- [Git-Backed Content](../concepts/git-backed-content.md)
+- [Authoring Surface](./authoring-surface.md)
+- [Content Operations App](../projects/content-operations-app.md)
+
+## Sources
+
+- [branching-workflows.md](../../raw/branching-workflows.md)
+- [CR-007: Decide Single Repo vs Split Content Repository](../../../change-requests/CR-007-decide-single-repo-vs-split-content-repository.md)

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -14,9 +14,10 @@ Catalog of LLM-maintained wiki pages. Read this first when querying or maintaini
 
 | Page | Summary |
 | --- | --- |
-| [Content Editor](./projects/content-editor.md) | Direction for the authoring/editor experience, including templates, assistant panel, and manifest questions. |
-| [Content Operations App](./projects/content-operations-app.md) | Scope and workflow memory for the local-first content operations direction. |
+| [Content Editor](./projects/content-editor.md) | Direction for the authoring/editor experience, including templates, planning assistance, assistant panel, and manifest questions. |
+| [Content Operations App](./projects/content-operations-app.md) | Scope and workflow memory for the local-first content operations direction, including pre-draft planning. |
 | [Content Pipeline](./projects/content-pipeline.md) | Build-time Markdown processing, generated content artifacts, and scaling considerations. |
+| [Story Crafter](./projects/story-crafter.md) | Future standalone feature idea for generated story series, continuity, and mobile reading workflows. |
 
 ## Concepts
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -14,8 +14,8 @@ Catalog of LLM-maintained wiki pages. Read this first when querying or maintaini
 
 | Page | Summary |
 | --- | --- |
-| [Content Editor](./projects/content-editor.md) | Direction for the authoring/editor experience, including templates, planning assistance, assistant panel, and manifest questions. |
-| [Content Operations App](./projects/content-operations-app.md) | Scope and workflow memory for the local-first content operations direction, including pre-draft planning. |
+| [Content Editor](./projects/content-editor.md) | Direction for the focused Electron content editor, including its boundary with VS Code, templates, planning assistance, assistant panel, and manifest questions. |
+| [Content Operations App](./projects/content-operations-app.md) | Scope and workflow memory for the local-first Electron content operations direction, with VS Code retained for source-code work. |
 | [Content Pipeline](./projects/content-pipeline.md) | Build-time Markdown processing, generated content artifacts, and scaling considerations. |
 | [Story Crafter](./projects/story-crafter.md) | Future standalone feature idea for generated story series, continuity, and mobile reading workflows. |
 
@@ -30,4 +30,5 @@ Catalog of LLM-maintained wiki pages. Read this first when querying or maintaini
 
 | Page | Summary |
 | --- | --- |
-| [Authoring Surface](./decisions/authoring-surface.md) | Current stance on browser, terminal, and desktop authoring surfaces. |
+| [Authoring Surface](./decisions/authoring-surface.md) | Current decision to use VS Code near term and a focused Electron app for future content operations. |
+| [Branching Workflow](./decisions/branching-workflow.md) | Branch-per-CR application workflow, short-lived content branches, and protected production-linked `main` branches. |

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,19 @@
 
 Append-only record of docs wiki activity.
 
+## [2026-05-28] ingest | Content planning note
+
+- Ingested `docs/raw/content-planning.md`.
+- Added content-planning assistant ideas to the content editor and content operations pages.
+- Added an open question about the most practical assistant suggestions for structured content plans.
+
+## [2026-05-28] ingest | Story Crafter note
+
+- Ingested `docs/raw/story-crafter.md` and linked sample/prompt sources.
+- Added a Story Crafter project page for the future generated story series feature idea.
+- Added open questions for Story Crafter content modeling, mobile reading delivery, and future CR ownership.
+- Preserved the constraint that Story Crafter should not expand the current `CR-017` work.
+
 ## [2026-05-23] ingest | Initial docs wiki migration
 
 - Created the `docs/raw/` and `docs/wiki/` structure.

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,28 @@
 
 Append-only record of docs wiki activity.
 
+## [2026-06-14] ingest | Branch protection update
+
+- Ingested the updated `Protecting main (default) branches` section from `docs/raw/branching-workflows.md`.
+- Recorded pull-request-only changes, required CI checks, blocked force pushes/deletion, and recovery-only administrative bypass.
+- Separated build-only pull-request validation from the single production deployment workflow.
+- Clarified that application and content `main` merges produce one combined Worker deployment.
+
+## [2026-06-14] ingest | Branching workflow note
+
+- Ingested `docs/raw/branching-workflows.md`.
+- Recorded one branch per CR for application work and short-lived branches for content creation and revision.
+- Clarified that `draft: true` is a publication safeguard, not a replacement for content branch isolation.
+- Recorded that hosted environments per branch are out of scope unless their value later outweighs the operational overhead.
+- Updated Git-backed content memory to reflect the chosen repository split.
+
+## [2026-06-14] ingest | Content authoring note
+
+- Ingested `docs/raw/content-authoring.md`.
+- Clarified that VS Code remains the near-term Markdown editor and source-code workspace.
+- Recorded Electron as the intended future content-focused editor for processing, organization, and publishing.
+- Preserved the boundary that Electron should not become an application source-code editor or execution environment.
+
 ## [2026-05-28] ingest | Content planning note
 
 - Ingested `docs/raw/content-planning.md`.

--- a/docs/wiki/overview.md
+++ b/docs/wiki/overview.md
@@ -17,6 +17,7 @@ The central direction is to keep Markdown in Git as the source of truth while im
 - [Content Editor](./projects/content-editor.md)
 - [Content Pipeline](./projects/content-pipeline.md)
 - [Content Operations App](./projects/content-operations-app.md)
+- [Story Crafter](./projects/story-crafter.md)
 - [Markdown Processing](./concepts/markdown-processing.md)
 - [Git-Backed Content](./concepts/git-backed-content.md)
 - [Authoring Surface](./decisions/authoring-surface.md)
@@ -29,3 +30,4 @@ The central direction is to keep Markdown in Git as the source of truth while im
 - [build-posts-improvements.md](../raw/build-posts-improvements.md)
 - [scaling-content-options.md](../raw/scaling-content-options.md)
 - [editor-design.md](../raw/editor-design.md)
+- [story-crafter.md](../raw/story-crafter.md)

--- a/docs/wiki/overview.md
+++ b/docs/wiki/overview.md
@@ -7,6 +7,8 @@ The central direction is to keep Markdown in Git as the source of truth while im
 ## Current Themes
 
 - Content is processed at build time and embedded into the Worker bundle because the Worker runtime has no filesystem access.
+- Publishable Markdown is moving to a separate content repository while code, change requests, docs/wiki knowledge, and experiments remain in the application repository.
+- Application work uses one branch per CR; content work uses short-lived content branches even though new content defaults to `draft: true`.
 - The authoring experience is moving toward template-driven content creation for posts and standalone pages.
 - The content pipeline should become more structured around metadata, AST processing, table of contents generation, validation, and domain content models.
 - The authoring surface should remain replaceable: browser, terminal/TUI, and desktop app options are all valid if they share the same content model and validation logic.
@@ -21,6 +23,7 @@ The central direction is to keep Markdown in Git as the source of truth while im
 - [Markdown Processing](./concepts/markdown-processing.md)
 - [Git-Backed Content](./concepts/git-backed-content.md)
 - [Authoring Surface](./decisions/authoring-surface.md)
+- [Branching Workflow](./decisions/branching-workflow.md)
 - [Open Questions](./questions.md)
 
 ## Sources
@@ -31,3 +34,4 @@ The central direction is to keep Markdown in Git as the source of truth while im
 - [scaling-content-options.md](../raw/scaling-content-options.md)
 - [editor-design.md](../raw/editor-design.md)
 - [story-crafter.md](../raw/story-crafter.md)
+- [branching-workflows.md](../raw/branching-workflows.md)

--- a/docs/wiki/projects/content-editor.md
+++ b/docs/wiki/projects/content-editor.md
@@ -22,6 +22,19 @@ The raw editor design note raises a manifest concept for each content item. The 
 
 This remains an open design question. It may become useful if suggestions, review state, or AI assistance history need to persist outside the Markdown file itself.
 
+## Content Planning
+
+The editor may also need a pre-draft planning mode where an assistant proposes a structured content plan before a Markdown file exists or before a rough note becomes publishable.
+
+Practical suggestions should likely stay close to authoring outcomes:
+
+- possible post angles from existing ideas or repository activity
+- outlines with sections, working titles, and likely metadata
+- gaps, audience questions, and follow-up prompts for the author
+- links to related existing content when a topic risks duplication or deserves a series
+
+This planning mode should feed the same template and validation workflow as draft creation. It should not become a separate content source of truth.
+
 ## Constraints
 
 - The editor should preserve Markdown files in Git as the canonical content source.
@@ -39,4 +52,5 @@ This remains an open design question. It may become useful if suggestions, revie
 
 - [editor-design.md](../../raw/editor-design.md)
 - [design-idea.png](../../raw/design-idea.png)
+- [content-planning.md](../../raw/content-planning.md)
 - [CR-006: Define Content Operations App Scope and Workflows](../../../change-requests/CR-006-define-content-operations-app-scope-and-workflows.md)

--- a/docs/wiki/projects/content-editor.md
+++ b/docs/wiki/projects/content-editor.md
@@ -4,6 +4,9 @@ The content editor direction is a focused authoring surface for creating and ref
 
 ## Current Direction
 
+- VS Code remains the default Markdown editor until the Electron editor is mature enough for daily content work.
+- The intended Electron editor is focused solely on content authoring and content operations.
+- Source-code viewing, editing, and execution remain VS Code responsibilities.
 - The editor should let the author create content from templates.
 - The currently identified templates are `About` and `Post`.
 - The left side can provide a `New...` action similar to a new-chat flow, opening template selection.
@@ -40,6 +43,7 @@ This planning mode should feed the same template and validation workflow as draf
 - The editor should preserve Markdown files in Git as the canonical content source.
 - AI assistance should improve authoring flow without hiding the underlying content model.
 - Editor-specific state should not leak into published content unless explicitly modeled.
+- The editor should not expand into a general-purpose application-code IDE.
 
 ## Related Pages
 
@@ -53,4 +57,5 @@ This planning mode should feed the same template and validation workflow as draf
 - [editor-design.md](../../raw/editor-design.md)
 - [design-idea.png](../../raw/design-idea.png)
 - [content-planning.md](../../raw/content-planning.md)
+- [content-authoring.md](../../raw/content-authoring.md)
 - [CR-006: Define Content Operations App Scope and Workflows](../../../change-requests/CR-006-define-content-operations-app-scope-and-workflows.md)

--- a/docs/wiki/projects/content-operations-app.md
+++ b/docs/wiki/projects/content-operations-app.md
@@ -7,6 +7,7 @@ The content operations direction is about making repository-backed content creat
 - Content should remain portable Markdown in the repository.
 - Authoring tools should be replaceable surfaces over shared content logic.
 - The system should support template-driven content creation, especially for posts and standalone pages.
+- Content planning can be a pre-draft workflow where an assistant suggests angles, outlines, and metadata before content generation.
 - Validation and publishing readiness should become explicit workflow steps.
 - AI assistance can help with editing and ambiguity, but unresolved assistance markers should block publish readiness when relevant.
 
@@ -30,6 +31,7 @@ The recent implementation direction emphasizes a narrow MVP:
 
 - [90-day-plan.md](../../raw/90-day-plan.md)
 - [next-steps.md](../../raw/next-steps.md)
+- [content-planning.md](../../raw/content-planning.md)
 - [CR-006: Define Content Operations App Scope and Workflows](../../../change-requests/CR-006-define-content-operations-app-scope-and-workflows.md)
 - [CR-015: Template-driven content generator](../../../change-requests/CR-015-template-driven-content-generator.md)
 - [CR-016: Render standalone About content](../../../change-requests/CR-016-render-standalone-about-content.md)

--- a/docs/wiki/projects/content-operations-app.md
+++ b/docs/wiki/projects/content-operations-app.md
@@ -6,6 +6,9 @@ The content operations direction is about making repository-backed content creat
 
 - Content should remain portable Markdown in the repository.
 - Authoring tools should be replaceable surfaces over shared content logic.
+- VS Code remains the default near-term Markdown editor until the Electron app is effective for daily use.
+- The Electron app should focus on content creation, processing, organization, and publishing.
+- Application source-code editing and execution should remain in VS Code rather than becoming Electron responsibilities.
 - The system should support template-driven content creation, especially for posts and standalone pages.
 - Content planning can be a pre-draft workflow where an assistant suggests angles, outlines, and metadata before content generation.
 - Validation and publishing readiness should become explicit workflow steps.
@@ -32,6 +35,7 @@ The recent implementation direction emphasizes a narrow MVP:
 - [90-day-plan.md](../../raw/90-day-plan.md)
 - [next-steps.md](../../raw/next-steps.md)
 - [content-planning.md](../../raw/content-planning.md)
+- [content-authoring.md](../../raw/content-authoring.md)
 - [CR-006: Define Content Operations App Scope and Workflows](../../../change-requests/CR-006-define-content-operations-app-scope-and-workflows.md)
 - [CR-015: Template-driven content generator](../../../change-requests/CR-015-template-driven-content-generator.md)
 - [CR-016: Render standalone About content](../../../change-requests/CR-016-render-standalone-about-content.md)

--- a/docs/wiki/projects/story-crafter.md
+++ b/docs/wiki/projects/story-crafter.md
@@ -1,0 +1,46 @@
+# Story Crafter
+
+Story Crafter is a future standalone feature idea for showcasing generated bedtime or read-aloud stories on `mylifeindigital`. The site has always been a place to showcase ideas and thinking, and Story Crafter can fit as one such idea rather than as a replacement for the existing blog/content workflow.
+
+This must not be folded into the current `CR-017` docs wiki work. Treat it as later feature planning after current change requests are complete.
+
+## Feature Idea
+
+- Create a standalone feature area or section where generated story series can live.
+- Use character combinations, settings, and values as the inputs for story generation.
+- Preserve continuity across stories so a series feels connected rather than like isolated one-off outputs.
+- Make the reading experience convenient on mobile, especially for bedtime reading.
+
+## Series Model
+
+The raw note imagines an Acorn Tree series with:
+
+- recurring characters: Acorn Tree, Squirrel, Frog, Mouse, Wagtail, and Robin
+- setting: a meadow with an acorn tree and a pond
+- themes or values: trust, humility, and similar life lessons
+
+The prompt source expands this into a multi-pass creative workflow with roles for continuity, story structure, drafting, child engagement review, values review, series-depth review, and final editing.
+
+## Workflow Memory
+
+The content workflow is intentionally unresolved. A likely future workflow is:
+
+- define a story series with characters, setting, values, reading level, and prior continuity
+- generate a polished story through the multi-pass prompt workflow
+- capture series notes or continuity details for future episodes
+- publish or deliver the result in an easy-to-read mobile format
+
+This suggests Story Crafter may need content models beyond ordinary posts, such as `story`, `story-series`, character metadata, continuity notes, and mobile reading layout decisions.
+
+## Related Pages
+
+- [Content Operations App](./content-operations-app.md)
+- [Content Editor](./content-editor.md)
+- [Open Questions](../questions.md)
+
+## Sources
+
+- [story-crafter.md](../../raw/story-crafter.md)
+- [story-crafter-sample1.md](../../raw/story-crafter-sample1.md)
+- [story-crafter-sample2.md](../../raw/story-crafter-sample2.md)
+- [story-crafter-prompt.md](../../raw/story-crafter-prompt.md)

--- a/docs/wiki/questions.md
+++ b/docs/wiki/questions.md
@@ -15,11 +15,6 @@ Questions that matter to future repository work.
 - What is the minimum domain content model needed before rendering?
 - Which validation failures should block local draft creation, preview, or publish readiness?
 
-## Repository Boundaries
-
-- Should content eventually move to its own repository, or should code and content stay together with better workflow discipline?
-- How much sync friction is acceptable before repository splitting becomes worth it?
-
 ## Authoring Surface
 
 - Should the primary authoring experience remain browser-based after the current 90-day window?
@@ -40,3 +35,4 @@ Questions that matter to future repository work.
 - [90-day-plan.md](../raw/90-day-plan.md)
 - [scaling-content-options.md](../raw/scaling-content-options.md)
 - [next-steps.md](../raw/next-steps.md)
+- [branching-workflows.md](../raw/branching-workflows.md)

--- a/docs/wiki/questions.md
+++ b/docs/wiki/questions.md
@@ -7,6 +7,7 @@ Questions that matter to future repository work.
 - Should each editable content item have a manifest that stores editing suggestions and source line references?
 - If manifests exist, are they draft-only workflow artifacts or part of the long-term content model?
 - How should AI editing suggestions be represented so they are reviewable without polluting published Markdown?
+- What are the most practical content-planning suggestions for the assistant to provide: post angles, outlines, metadata, series links, gap analysis, or something else?
 
 ## Content Pipeline
 
@@ -24,9 +25,18 @@ Questions that matter to future repository work.
 - Should the primary authoring experience remain browser-based after the current 90-day window?
 - Would a TUI or desktop app better support the primary user's writing flow?
 
+## Story Crafter
+
+- Should Story Crafter live as a normal content section, a standalone feature area, or a separate experiment before becoming public site content?
+- What content model is needed for generated story series: story, series, characters, settings, values, continuity notes, or all of these?
+- How should generated stories be delivered in a mobile-friendly format for bedtime reading?
+- When current change requests are complete, which future CR should own Story Crafter planning without expanding `CR-017`?
+
 ## Sources
 
 - [editor-design.md](../raw/editor-design.md)
+- [content-planning.md](../raw/content-planning.md)
+- [story-crafter.md](../raw/story-crafter.md)
 - [90-day-plan.md](../raw/90-day-plan.md)
 - [scaling-content-options.md](../raw/scaling-content-options.md)
 - [next-steps.md](../raw/next-steps.md)


### PR DESCRIPTION
## Summary

This PR records the CR-007 decision to split publishable Markdown content into a dedicated `mylifeindigital.content` repository while keeping the application code, build tooling, deployment configuration, docs/wiki, and change requests in `mylifeindigital`.

It expands CR-007 into a full architecture decision covering repository ownership, authoring workflow, Cloudflare/GitHub Actions deployment implications, generated artifacts, VS Code workflow, branch rules, and migration planning.

## What Changed

- Completed the CR-007 decision document for the split content repository model.
- Added follow-up CRs for the implementation work:
  - CR-008 publishing workflow rules
  - CR-014 generated content artifact strategy
  - CR-018 web admin role after the split
  - CR-019 split-repository GitHub Actions CI/CD
  - CR-020 content repository creation and file migration
  - CR-021 `CONTENT_DIR` support for content tooling
  - CR-022 README, workspace, and local docs updates
  - CR-023 baseline test setup
- Added raw migration and authoring notes for the repository split.
- Updated docs wiki pages for Git-backed content, authoring surface, branching workflow, content operations, and Story Crafter notes.
- Updated the repository changelog and change-request index.

## Key Decisions

- Publishable Markdown moves to `mylifeindigital.content`.
- Markdown in Git remains the canonical content source.
- `mylifeindigital` remains the application/code/docs/change-request repository.
- VS Code remains the near-term Markdown authoring tool.
- The Electron/content operations app should operate on the content repository rather than requiring normal content work in the app codebase.
- GitHub Actions becomes the future split-repository build/deploy orchestrator.
- Cloudflare remains the Worker runtime and deployment target.
- `posts-data.ts` remains generated-only and should not become authored content.
- Preview deployments are out of scope initially.

## Verification

- Reviewed branch diff against `main`.
- Working tree is clean.
- `git diff --check main...HEAD` reports trailing whitespace in Markdown metadata/raw-note lines. These are documentation-formatting issues, not runtime code issues.
- No app build or test suite was run; this PR is documentation/planning only.