### PR TITLE
CR-008 Updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Repository-level changes for `mylifeindigital`. Web app release changes are trac
 - Added `CR-021` to add `CONTENT_DIR` support to build and content-authoring tooling.
 - Added `CR-022` to update README, VS Code workspace, and local split-repository documentation.
 
+### Changed
+
+- Reconciled `CR-007` as complete after confirming its split-repository decision, follow-up implementation requests, and outcome were already documented.
+- Completed `CR-008` publishing workflow rules, including generator-bypass handling and blocking versus warning validation behavior.
+- Updated the workflow-rules raw note so it no longer depends on a temporary content draft after `CR-008` completion.
+
 ## 2026-06-14
 
 ### Added

--- a/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
+++ b/change-requests/CR-007-decide-single-repo-vs-split-content-repository.md
@@ -1,6 +1,6 @@
 # CR-007: Decide Single Repo vs Split Content Repository
 
-Status: Proposed  
+Status: Done
 Priority: High  
 Area: Architecture  
 Created: 2026-05-06

--- a/change-requests/CR-008-define-publishing-workflow-rules.md
+++ b/change-requests/CR-008-define-publishing-workflow-rules.md
@@ -1,6 +1,6 @@
 # CR-008: Define Publishing Workflow Rules
 
-Status: Proposed  
+Status: Done
 Priority: High  
 Area: Publishing  
 Created: 2026-05-06
@@ -38,6 +38,21 @@ Use the following publishing lifecycle:
 
 The `draft` flag is a publication safeguard, not a replacement for branch isolation or validation.
 
+### Authoring And Enforcement Rules
+
+The preferred authoring path for new content is the template generator, currently `npm run new-content`, because it creates the expected file location, frontmatter shape, content type, layout, slug behavior, and `draft: true` default. After the split, the generator should target the configured content repository path rather than the application repository branch, as owned by `CR-021`.
+
+The workflow must not rely on generator usage as the only correctness mechanism. A manually created Markdown file can still enter the publishing workflow, but it must satisfy the same content validation rules as generated content before it can merge or publish. If a manually created file is missing required frontmatter, content-type metadata, slug/path expectations, `draft`, required assets, or any other publication requirement, pull-request validation should fail with a blocking error.
+
+Enforcement happens at multiple layers:
+
+- Branch protection prevents direct routine writes to content `main`.
+- Pull requests make content changes reviewable before they can merge.
+- Content validation checks the authored Markdown result, regardless of whether the file was generated or created manually.
+- The production deployment workflow builds from selected application and content refs only after trusted `main` refs or an explicit manual dispatch have been selected.
+
+Generator use is therefore a recommended creation rule and may be encouraged by documentation or future tooling, but publication safety is enforced by branch protection, pull requests, validation, and deployment ref selection.
+
 ### Publish-Readiness Rules
 
 A content item is publish-ready when:
@@ -51,6 +66,10 @@ A content item is publish-ready when:
 - the content change has been reviewed through its pull request, even when no second-person approval is required.
 
 Warnings that do not affect correctness may remain non-blocking, but the validation system should distinguish warnings from publication blockers.
+
+Blocking errors include missing required metadata, invalid frontmatter, invalid content-type metadata, `draft: true` or a missing `draft` state for content intended to publish, unresolved AI assistance markers, missing required assets, Markdown processing failures, failed application compatibility checks, and any other condition that would make the deployed content incorrect or incomplete.
+
+Non-blocking warnings may include optional metadata suggestions, editorial recommendations, non-critical asset improvements, or advisory checks that do not affect publication correctness. Warnings should be visible in pull-request validation output without preventing merge or deployment unless they are promoted to blockers by the validation policy.
 
 OpenAI-backed image generation should not run as part of every validation pass. It should be an explicit or optional workflow and should block publication only when the content requires a generated image that is missing or invalid.
 
@@ -102,22 +121,22 @@ If the source content itself must be corrected or withdrawn, make that change th
 
 ## Acceptance Criteria
 
-- [ ] The content lifecycle from branch creation through confirmed production deployment is documented.
-- [ ] Publish-readiness rules distinguish blocking errors from non-blocking warnings.
-- [ ] New content defaults to `draft: true`, and `draft: false` is required before publication.
-- [ ] The workflow requires content branches and pull requests rather than using draft status as the only isolation mechanism.
-- [ ] Pull requests run validation without production deployment.
-- [ ] Content `main` merges request production deployment through the application repository.
-- [ ] Application `main` deployment triggers are defined.
-- [ ] The application repository is the only owner of `wrangler deploy`.
-- [ ] Initial application/content ref selection rules are documented.
-- [ ] Manual deployment with explicit application and content refs is supported for recovery.
-- [ ] Branch protection and solo-author approval rules are documented.
-- [ ] Image generation behavior distinguishes ordinary validation from required publication assets.
-- [ ] Failed deployment behavior distinguishes a merged content change from a completed publication.
-- [ ] Rollback uses explicit known-good application and content SHAs.
-- [ ] Hosted preview deployments are explicitly out of scope for the initial workflow.
-- [ ] Dependencies and ownership boundaries with `CR-007`, `CR-013`, `CR-014`, and `CR-019` are explicit.
+- [x] The content lifecycle from branch creation through confirmed production deployment is documented.
+- [x] Publish-readiness rules distinguish blocking errors from non-blocking warnings.
+- [x] New content defaults to `draft: true`, and `draft: false` is required before publication.
+- [x] The workflow requires content branches and pull requests rather than using draft status as the only isolation mechanism.
+- [x] Pull requests run validation without production deployment.
+- [x] Content `main` merges request production deployment through the application repository.
+- [x] Application `main` deployment triggers are defined.
+- [x] The application repository is the only owner of `wrangler deploy`.
+- [x] Initial application/content ref selection rules are documented.
+- [x] Manual deployment with explicit application and content refs is supported for recovery.
+- [x] Branch protection and solo-author approval rules are documented.
+- [x] Image generation behavior distinguishes ordinary validation from required publication assets.
+- [x] Failed deployment behavior distinguishes a merged content change from a completed publication.
+- [x] Rollback uses explicit known-good application and content SHAs.
+- [x] Hosted preview deployments are explicitly out of scope for the initial workflow.
+- [x] Dependencies and ownership boundaries with `CR-007`, `CR-013`, `CR-014`, and `CR-019` are explicit.
 
 ## Implementation Notes
 
@@ -127,7 +146,11 @@ If the source content itself must be corrected or withdrawn, make that change th
 - Generated artifact ownership remains a separate concern under `CR-014`.
 - Related wiki decision: `docs/wiki/decisions/branching-workflow.md`.
 - Related source note: `docs/raw/content-split.md`.
+- Supporting source note: `docs/raw/workflow-rules.md`.
+- `docs/raw/workflow-rules.md` raised the practical generator-bypass question. The rule is that `npm run new-content` is the preferred creation path, but validation enforces the final Markdown shape. Manually created files are not automatically trusted and cannot publish unless they satisfy the same blocking validation requirements as generated content.
 
 ## Outcome
 
-Pending decision.
+Publishing workflow rules are defined for the split-repository model. Content publishing uses short-lived content branches, generator-created draft defaults where possible, pull requests, validation, protected `main`, application-owned production deployment, explicit application/content refs, visible deployment failure handling, and rollback by known-good application and content SHAs.
+
+Implementation remains with `CR-019`. Detailed validation check behavior remains with `CR-013`. Generated artifact ownership remains with `CR-014`. Repository boundary and migration planning remain with `CR-007`, `CR-020`, `CR-021`, and `CR-022`.

--- a/change-requests/index.md
+++ b/change-requests/index.md
@@ -20,8 +20,8 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 | CR-004 | Remove Monaco editor from web admin | Done | Medium | Web Admin | 2026-05-06 | [CR-004-remove-monaco-editor-from-web-admin.md](./CR-004-remove-monaco-editor-from-web-admin.md) |
 | CR-005 | Decide Electron vs Tauri for content operations app | Done | High | Content Operations | 2026-05-06 | [CR-005-decide-electron-vs-tauri-for-content-operations-app.md](./CR-005-decide-electron-vs-tauri-for-content-operations-app.md) |
 | CR-006 | Define content operations app scope and workflows | Done | High | Content Operations | 2026-05-06 | [CR-006-define-content-operations-app-scope-and-workflows.md](./CR-006-define-content-operations-app-scope-and-workflows.md) |
-| CR-007 | Decide single repo vs split content repository | Proposed | High | Architecture | 2026-05-06 | [CR-007-decide-single-repo-vs-split-content-repository.md](./CR-007-decide-single-repo-vs-split-content-repository.md) |
-| CR-008 | Define publishing workflow rules | Proposed | High | Publishing | 2026-05-06 | [CR-008-define-publishing-workflow-rules.md](./CR-008-define-publishing-workflow-rules.md) |
+| CR-007 | Decide single repo vs split content repository | Done | High | Architecture | 2026-05-06 | [CR-007-decide-single-repo-vs-split-content-repository.md](./CR-007-decide-single-repo-vs-split-content-repository.md) |
+| CR-008 | Define publishing workflow rules | Done | High | Publishing | 2026-05-06 | [CR-008-define-publishing-workflow-rules.md](./CR-008-define-publishing-workflow-rules.md) |
 | CR-009 | Add admin metadata editing UI | Proposed | Medium | Web Admin | 2026-05-06 | Pending detail |
 | CR-010 | Add admin validation panel and author-facing warnings | Proposed | High | Web Admin | 2026-05-06 | Pending detail |
 | CR-011 | Spike browser-worker preview pipeline | Proposed | Medium | Content Pipeline | 2026-05-06 | Pending detail |
@@ -42,6 +42,8 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 
 ### 2026-06-16
 
+- Reconciled `CR-007` as `Done` because its split-repository decision, migration plan, follow-up CRs, acceptance criteria, outcome, and wiki references were already complete.
+- Completed `CR-008` by clarifying generator-bypass handling, blocking versus warning validation behavior, and publishing workflow ownership boundaries.
 - Added `CR-020` as the focused implementation request for creating `mylifeindigital.content` and migrating publishable Markdown files.
 - Added `CR-021` as the focused implementation request for adding `CONTENT_DIR` support to build and content-authoring tooling.
 - Added `CR-022` as the focused documentation request for README, VS Code workspace, and local split-repository setup guidance.

--- a/docs/raw/workflow-rules.md
+++ b/docs/raw/workflow-rules.md
@@ -1,0 +1,21 @@
+# Workflow Rules
+
+This note supported [CR-008: Define Publishing Workflow Rules](../../change-requests/CR-008-define-publishing-workflow-rules.md). The original idea was to create a temporary content piece in the current branch and use it to reason through the workflow rules. That content piece has been removed because `CR-008` is now `Done`, and keeping a throwaway draft around no longer adds value.
+
+The useful question from the exercise remains: one of the publishing rules says each new content piece should be created on a branch and merged through a pull request. How is that enforced?
+
+The answer captured in `CR-008` is layered enforcement:
+
+- Protect `main` in the content repository.
+- Require pull requests before content can merge.
+- Run CI validation on pull requests without deploying production.
+- Validate the authored Markdown result, not just the command used to create it.
+- Trigger production deployment only from trusted `main` refs or explicit manual dispatches handled by the application repository.
+
+Another useful question was whether `npm run new-content` must be used. The preferred authoring path is still the template generator because it creates the expected frontmatter, content type, layout, slug behavior, and `draft: true` default. But publication safety cannot depend on trusting that the generator was used. A manually created Markdown file may enter the workflow, but it must satisfy the same validation rules before it can merge or publish.
+
+That means validation should fail with a blocking error when required metadata is missing, frontmatter is invalid, `draft` is missing or still `true` for content intended to publish, required assets are missing, unresolved AI assistance markers remain, or Markdown processing/application compatibility checks fail.
+
+Non-blocking warnings can still exist for editorial or optional metadata suggestions, but the validation system must clearly distinguish warnings from publication blockers.
+
+No new content piece is needed to complete `CR-008`. Future implementation evidence should come from the validation and CI work owned by `CR-013` and `CR-019`, using fixtures or focused test content where needed rather than keeping an unrelated publishable draft in the repository.


### PR DESCRIPTION
## Summary

Completes `CR-008: Define Publishing Workflow Rules` for the split content/application repository workflow.

This PR documents the publishing lifecycle from content branch creation through confirmed production deployment, including publish-readiness rules, deployment trigger ownership, branch protection expectations, failure handling, rollback behavior, and boundaries with related follow-up CRs.

## Changes

- Marked `CR-008` as `Done`.
- Documented the content publishing lifecycle from branch creation to production deployment.
- Clarified that `draft: true` is a safeguard, not a replacement for branches, pull requests, or validation.
- Added authoring enforcement rules for generated and manually created Markdown files.
- Defined blocking validation errors versus non-blocking warnings.
- Confirmed that pull requests validate without deploying production.
- Documented that content `main` merges request deployment through the application repository.
- Confirmed the application repository is the only owner of `wrangler deploy`.
- Documented manual deployment with explicit application and content refs for recovery.
- Clarified rollback by known-good application/content SHAs.
- Updated the raw workflow note after removing the temporary content draft experiment.
- Updated the change request dashboard and changelog.

## Notes

No new content piece is required for `CR-008`. Future implementation evidence belongs in `CR-013` for content validation behavior and `CR-019` for GitHub Actions CI/CD enforcement.

## Verification

- Confirmed `CR-008` acceptance criteria are checked.
- Confirmed `CR-008` has a final outcome.
- Ran Markdown/diff whitespace validation with `git diff --check`.
- No runtime tests were run because this is documentation and planning work only.