### PR TITLE
Add CR-009 metadata editing detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Repository-level changes for `mylifeindigital`. Web app release changes are trac
 
 ### Added
 
+- Added the `CR-009` detail file to define admin metadata editing scope and capture its dependency on the web-admin role decision in `CR-018`.
 - Added `CR-020` to create `mylifeindigital.content` and migrate publishable Markdown files out of the application repository.
 - Added `CR-021` to add `CONTENT_DIR` support to build and content-authoring tooling.
 - Added `CR-022` to update README, VS Code workspace, and local split-repository documentation.

--- a/change-requests/CR-009-add-admin-metadata-editing-ui.md
+++ b/change-requests/CR-009-add-admin-metadata-editing-ui.md
@@ -1,0 +1,88 @@
+# CR-009: Add Admin Metadata Editing UI
+
+Status: Proposed  
+Priority: Medium  
+Area: Web Admin  
+Created: 2026-05-06
+
+## Context
+
+Markdown frontmatter is part of the publishing interface for `mylifeindigital`. It controls title, dates, author information, descriptions, tags, draft state, section placement, image metadata, hero behavior, and future content-type-specific workflow rules.
+
+The current browser admin can open, edit, preview, save, and create Markdown files, but metadata is still edited directly in the raw Markdown source. That keeps the implementation simple, but it makes common authoring tasks easy to mistype and leaves metadata completeness mostly implicit until preview, build, or later validation catches an issue.
+
+`CR-006` defines metadata management as part of the broader content operations direction and notes that content type should eventually drive metadata schema, validation rules, template selection, and editing UI. The 90-day plan also called out metadata editing support as a browser-authoring improvement.
+
+This request is now partly affected by later repository-boundary decisions. `CR-018` still needs to decide the future role of the browser admin after publishable content moves toward a split content repository. CR-009 should therefore avoid assuming that the browser admin remains the long-term primary write-capable authoring surface.
+
+## Goal
+
+Define and, if still appropriate after the web-admin role decision, add a small admin metadata editing UI that makes common frontmatter fields easier to inspect and edit without replacing Markdown-in-Git as the source of truth.
+
+## Proposed Implementation
+
+Treat this request as a focused web-admin improvement, not as a full CMS or the definitive future content operations UI.
+
+Start by documenting the metadata editing contract for the existing admin surface:
+
+- Markdown files remain the canonical content representation.
+- The metadata UI reads from and writes back to frontmatter.
+- Unknown or unsupported frontmatter fields must be preserved.
+- The raw Markdown editor remains available so manual corrections are always possible.
+- Metadata edits and raw editor edits share the same dirty-state, save, preview, and unsaved-change behavior.
+
+If browser-admin editing remains in scope after `CR-018`, add a compact metadata panel alongside the existing editor/preview flow for the common metadata fields already used by the app:
+
+- `title`
+- `date`
+- `updated`
+- `author`
+- `description`
+- `tags`
+- `section`
+- `draft`
+- `image`
+- `imageMobile`
+- `imageAlt`
+- `heroSection.title`
+- `heroSection.subtitle`
+- `heroSection.showOnHomepage`
+
+The implementation should prefer structured parsing and serialization for frontmatter over ad hoc string edits. If a shared helper is added, it should be usable by future admin validation work in `CR-010` and by later content-operations tooling where practical.
+
+If `CR-018` decides that browser-admin content editing should be removed, disabled, or made read-only, repurpose this request into one of these smaller outcomes:
+
+- a read-only metadata inspection panel,
+- a documented handoff to the future Electron content operations app,
+- or a dropped browser-admin implementation with rationale captured in `Outcome`.
+
+## Acceptance Criteria
+
+- [ ] The request is reconciled with `CR-018` before implementation commits to a write-capable browser-admin metadata editor.
+- [ ] The chosen metadata editing scope is documented: editable panel, read-only panel, Electron handoff, or dropped browser-admin implementation.
+- [ ] The metadata UI, if implemented, reads frontmatter from the currently opened Markdown file.
+- [ ] The metadata UI, if implemented, can update common frontmatter fields while preserving unsupported or unknown frontmatter keys.
+- [ ] Metadata edits participate in the existing dirty-state, save, preview, and unsaved-change flows.
+- [ ] Raw Markdown editing remains available for fields or structures not covered by the metadata UI.
+- [ ] The implementation avoids lossy frontmatter serialization for nested metadata such as `heroSection`.
+- [ ] The implementation notes identify any follow-up validation work that belongs in `CR-010`.
+- [ ] Web app version and `web/CHANGELOG.md` are updated if runtime web-admin behavior changes.
+- [ ] Relevant web build or focused validation checks are run and recorded.
+
+## Implementation Notes
+
+- Existing admin dashboard route: `web/src/routes/admin/dashboard.ts`.
+- Existing admin API routes: `web/src/routes/admin/api.ts`.
+- Current inline dashboard implementation: `web/src/utils/admin/html.ts`.
+- Current admin editor styles: `web/public/styles/admin.css`.
+- Current content metadata type: `web/src/utils/markdown.ts`.
+- Current frontmatter parsing in the pipeline uses `gray-matter` through `web/src/utils/pipeline/processors/FrontmatterProcessor.ts`.
+- The preview endpoint already returns parsed metadata from the processing pipeline.
+- Related completed editor baseline: `CR-004`.
+- Related content-operations scope: `CR-006`.
+- Related web-admin role decision: `CR-018`.
+- Related future validation work: `CR-010`.
+
+## Outcome
+
+Pending.

--- a/change-requests/index.md
+++ b/change-requests/index.md
@@ -22,7 +22,7 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 | CR-006 | Define content operations app scope and workflows | Done | High | Content Operations | 2026-05-06 | [CR-006-define-content-operations-app-scope-and-workflows.md](./CR-006-define-content-operations-app-scope-and-workflows.md) |
 | CR-007 | Decide single repo vs split content repository | Done | High | Architecture | 2026-05-06 | [CR-007-decide-single-repo-vs-split-content-repository.md](./CR-007-decide-single-repo-vs-split-content-repository.md) |
 | CR-008 | Define publishing workflow rules | Done | High | Publishing | 2026-05-06 | [CR-008-define-publishing-workflow-rules.md](./CR-008-define-publishing-workflow-rules.md) |
-| CR-009 | Add admin metadata editing UI | Proposed | Medium | Web Admin | 2026-05-06 | Pending detail |
+| CR-009 | Add admin metadata editing UI | Proposed | Medium | Web Admin | 2026-05-06 | [CR-009-add-admin-metadata-editing-ui.md](./CR-009-add-admin-metadata-editing-ui.md) |
 | CR-010 | Add admin validation panel and author-facing warnings | Proposed | High | Web Admin | 2026-05-06 | Pending detail |
 | CR-011 | Spike browser-worker preview pipeline | Proposed | Medium | Content Pipeline | 2026-05-06 | Pending detail |
 | CR-012 | Decide parser roadmap for markdown processing | Proposed | Medium | Content Pipeline | 2026-05-06 | Pending detail |
@@ -44,6 +44,7 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 
 - Reconciled `CR-007` as `Done` because its split-repository decision, migration plan, follow-up CRs, acceptance criteria, outcome, and wiki references were already complete.
 - Completed `CR-008` by clarifying generator-bypass handling, blocking versus warning validation behavior, and publishing workflow ownership boundaries.
+- Added the `CR-009` detail file to define admin metadata editing scope and capture its dependency on the web-admin role decision in `CR-018`.
 - Added `CR-020` as the focused implementation request for creating `mylifeindigital.content` and migrating publishable Markdown files.
 - Added `CR-021` as the focused implementation request for adding `CONTENT_DIR` support to build and content-authoring tooling.
 - Added `CR-022` as the focused documentation request for README, VS Code workspace, and local split-repository setup guidance.
@@ -59,11 +60,11 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 
 ### 2026-05-23
 
-- Detail coverage at this pass: `CR-001` through `CR-008` and `CR-015` through `CR-019` have detail files. `CR-009` through `CR-014` remain lightweight proposed rows and need detail files before they move toward planning or implementation.
+- Detail coverage at this pass: `CR-001` through `CR-008` and `CR-015` through `CR-019` have detail files. At the time of the pass, `CR-009` through `CR-014` remained lightweight proposed rows and needed detail files before they moved toward planning or implementation.
 - Status reconciliation: `CR-005` is complete in the dashboard and now matches its detail file status. Its acceptance criteria are checked and its outcome records the Electron decision.
 - Completed follow-up slices: `CR-015` and `CR-016` completed two concrete follow-ups from `CR-006`: template-driven content generation and standalone About rendering.
 - High-priority decisions: `CR-007` defines the repository boundary and `CR-008` now defines the publishing workflow rules that `CR-019` should implement.
-- Related admin work: `CR-009` and `CR-010` should be detailed together before implementation so metadata editing and validation-panel boundaries stay clear.
+- Related admin work: `CR-009` and `CR-010` should keep metadata editing and validation-panel boundaries clear before implementation.
 - Related pipeline work: `CR-011`, `CR-012`, `CR-013`, and `CR-014` overlap around preview, parsing, validation, and generated artifacts. Detail files should clarify dependencies before any one of them moves to `Planned`.
 
 ## Status Guide


### PR DESCRIPTION
## Summary

- Added the missing `CR-009` detail document for admin metadata editing UI.
- Linked `CR-009` from the change request dashboard.
- Recorded the planning update in the root changelog.
- Clarified older grooming notes so they no longer read as if CR-009 is still undocumented.

## Notes

This keeps CR-009 in a proposed/parking state. The detail document explicitly calls out that implementation should wait until `CR-018` decides the future role of the browser admin after the content repository split.

## Verification

- Reviewed the Markdown diff.
- No tests run; documentation/planning-only change.