### PR TITLE
CR-011 Spike for browser worker preview pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Repository-level changes for `mylifeindigital`. Web app release changes are tracked separately in `web/CHANGELOG.md`.
 
+## 2026-06-20
+
+### Added
+
+- Added the `CR-011` detail file to define the browser-worker preview spike, preview parity questions, and its relationship to validation, parser roadmap, CI validation, and generated artifact work.
+- Added preview parity comparison scripts for `CR-011` that compare current admin preview, real-identity admin preview, and build-time pipeline output for representative content fixtures.
+- Added a minimal browser-worker preview proof-of-concept for `CR-011`, including browser-target bundling and representative fixture parity checks.
+
+### Changed
+
+- Completed `CR-011` with a proceed-cautiously outcome for browser-worker preview and server-preview fallback.
+
 ## 2026-06-16
 
 ### Added

--- a/change-requests/CR-011-spike-browser-worker-preview-pipeline.md
+++ b/change-requests/CR-011-spike-browser-worker-preview-pipeline.md
@@ -1,0 +1,312 @@
+# CR-011: Spike Browser-Worker Preview Pipeline
+
+Status: Done  
+Priority: Medium  
+Area: Content Pipeline  
+Created: 2026-05-06
+
+## Context
+
+The current admin preview path is server-side. `POST /api/admin/preview` receives Markdown, runs the Markdown processing pipeline in the Worker route, and returns rendered HTML, table of contents data, and parsed metadata. That gives the admin a useful preview, but it keeps fast editing feedback coupled to a server round trip and does not yet prove that the content pipeline can run in browser-safe authoring environments.
+
+The 90-day planning notes describe a future `content-core` layer for pure, environment-neutral Markdown processing: frontmatter parsing, Markdown parsing, AST creation, table of contents extraction, validation, domain mapping, HTML rendering, and warning generation. That layer should be able to run in the browser, in a browser worker, in CLI/TUI tooling, in Cloudflare Workers, in Node build scripts, and in a desktop shell.
+
+`CR-006` established the broader content-operations direction: local processing should use the same pipeline shape as the build so authors can preview what will actually be published. `CR-007` later clarified that local preview remains the initial workflow after the split-repository decision; hosted preview deployments are intentionally out of scope until they prove recurring value.
+
+This request exists to test the browser-worker preview idea before committing the web admin, future Electron app, or content tooling to a larger refactor.
+
+## Goal
+
+Run a focused spike that determines whether enough of the Markdown processing pipeline can execute in a browser worker to provide fast, trustworthy authoring preview while preserving clear parity rules with server preview and build-time output.
+
+## Proposed Implementation
+
+Treat this as an investigation and proof-of-concept, not a full production preview rewrite.
+
+Start by documenting the current preview pipeline:
+
+- which processors run for admin server preview;
+- which processors run for build-time content generation;
+- which processors are pure and browser-safe;
+- which processors depend on runtime-only capabilities such as Git, filesystem access, external APIs, image generation, deployment configuration, or Worker-only behavior.
+
+Define preview parity rules before or during the spike:
+
+- Browser-worker preview should use the same core Markdown semantics as server preview and build output.
+- Runtime-only enrichments must be explicit and must not silently change the preview contract.
+- Server preview should remain the authoritative fallback for behavior that cannot safely run in the browser.
+- Any known differences between browser-worker preview, server preview, and build output must be documented for authors and future implementers.
+
+Build the smallest useful proof-of-concept if the initial processor inventory supports it. The spike may use a local-only worker entry point, small fixture content, or a hidden/internal admin path. It does not need to replace the existing preview UI.
+
+Evaluate:
+
+- bundling constraints for running the pipeline in a browser worker;
+- whether existing Markdown/frontmatter dependencies work in the browser-worker target;
+- whether processor outputs match server preview for representative Markdown fixtures;
+- how warnings, validation output, metadata, TOC data, and rendered HTML would flow back to the authoring UI;
+- whether the approach should wait for parser or pipeline decisions owned by `CR-012`.
+
+End the spike by recording one of these outcomes:
+
+- proceed with a browser-worker preview implementation;
+- keep server preview as the primary path and only extract shared helpers for now;
+- defer the browser-worker path until parser/pipeline refactoring is complete;
+- drop the browser-worker approach with rationale.
+
+## Acceptance Criteria
+
+- [x] The current admin preview and build-time pipeline differences are documented.
+- [x] Processors are classified as browser-safe core processing or runtime-only processing.
+- [x] Preview parity rules are written down, including how browser-worker preview relates to server preview and build output.
+- [x] A minimal proof-of-concept is attempted if the processor inventory shows a practical path.
+- [x] The spike records bundling, dependency, and Worker/browser compatibility findings.
+- [x] The spike records whether warnings, validation output, metadata, TOC data, and rendered HTML can share a stable result shape across preview paths.
+- [x] Any fixture or parity checks created during the spike are documented.
+- [x] The outcome recommends proceed, defer, keep server preview, or drop the browser-worker approach.
+- [x] Follow-up implementation requests are identified without expanding this spike into full production preview work.
+
+## Implementation Notes
+
+- Existing admin preview endpoint: `web/src/routes/admin/api.ts`.
+- Current admin preview UI: `web/src/utils/admin/html.ts`.
+- Current Markdown pipeline entry point: `web/src/utils/pipeline/MarkdownProcessingPipeline.ts`.
+- Current pipeline processors live under `web/src/utils/pipeline/processors/`.
+- Build-time content generation lives in `web/scripts/build-posts.ts`.
+- Preview parity comparison helper: `web/scripts/compare-preview-parity.ts`.
+- Root preview parity npm command: `npm run compare:preview-parity`.
+- Preview parity npm command: `cd web && npm run compare:preview-parity`.
+- Browser-worker preview processing helper: `web/src/utils/pipeline/browser-preview.ts`.
+- Browser-worker preview entry point: `web/src/workers/preview-worker.ts`.
+- Browser-worker POC helper: `web/scripts/run-preview-worker-poc.ts`.
+- Root browser-worker POC npm command: `npm run preview-worker:poc`.
+- Browser-worker POC npm command: `cd web && npm run preview-worker:poc`.
+- Generated runtime content data lives in `web/src/utils/posts-data.ts` and should not be edited manually.
+- Related content-operations scope: `CR-006`.
+- Related split-repository and local-preview decision: `CR-007`.
+- Related validation panel work: `CR-010`.
+- Related parser roadmap decision: `CR-012`.
+- Related CI content validation work: `CR-013`.
+- Related generated artifact strategy: `CR-014`.
+
+### Current Pipeline Comparison
+
+The current admin preview route builds its pipeline inline in `web/src/routes/admin/api.ts`:
+
+```text
+FrontmatterProcessor -> ExcludeProcessor -> AstProcessor -> TocProcessor -> HtmlProcessor
+```
+
+The build-time content generation pipeline is created in `web/scripts/build-posts.ts`:
+
+```text
+FrontmatterProcessor -> DraftFilterProcessor -> GitDateProcessor -> ExcludeProcessor -> optional ImageGeneratorProcessor -> AstProcessor -> TocProcessor -> HtmlProcessor
+```
+
+| Processor | Current location | Admin preview | Build-time generation | Notes |
+| --- | --- | --- | --- | --- |
+| `FrontmatterProcessor` | `web/src/utils/pipeline/processors/FrontmatterProcessor.ts` | Yes | Yes | Parses YAML frontmatter, sets `context.body`, and builds `context.metadata`. |
+| `DraftFilterProcessor` | `web/src/utils/pipeline/processors/DraftFilterProcessor.ts` | No | Yes | Skips `draft: true` content during generated content builds. Admin preview intentionally still renders drafts. |
+| `GitDateProcessor` | `web/scripts/processors/GitDateProcessor.ts` | No | Yes | Uses `git log` through Node `child_process` to enrich `metadata.updated`; this is runtime/build-only and not browser-worker safe. |
+| `ExcludeProcessor` | `web/src/utils/pipeline/processors/ExcludeProcessor.ts` | Yes | Yes | Removes content between `exclude-start` and `exclude-end` comments before AST generation. |
+| `ImageGeneratorProcessor` | `web/scripts/processors/ImageGeneratorProcessor.ts` | No | Optional | Generates AI images, resizes them, uploads to R2, and updates image metadata/manifest; this is external-service/build-only work. |
+| `AstProcessor` | `web/src/utils/pipeline/processors/AstProcessor.ts` | Yes | Yes | Uses `marked.lexer()` to create the token AST from the Markdown body. |
+| `TocProcessor` | `web/src/utils/pipeline/processors/TocProcessor.ts` | Yes | Yes | Extracts heading tokens into `context.toc`; both current paths use heading levels 1 through 3. |
+| `HtmlProcessor` | `web/src/utils/pipeline/processors/HtmlProcessor.ts` | Yes | Yes | Renders Markdown/AST to HTML and adds heading IDs for TOC anchors. |
+
+Known behavioral differences:
+
+- Admin preview does not filter drafts; build-time generation skips draft content.
+- Admin preview does not enrich `updated` metadata from Git; build-time generation may add it through `GitDateProcessor`.
+- Admin preview does not generate, resize, upload, cache, or attach images; build-time generation can do this when image generation is enabled.
+- Admin preview does not write generated artifacts; build-time generation writes `web/src/utils/posts-data.ts`.
+- Both paths parse frontmatter, apply exclude markers, generate an AST, produce a table of contents, and render HTML.
+- Script-only processors currently depend on Node, Git, external services, R2, image processing, and manifest writes, so they are not candidates for direct browser-worker execution.
+
+### Processor Classification
+
+| Processor | Classification | Reason |
+| --- | --- | --- |
+| `FrontmatterProcessor` | Browser-safe core candidate | Uses `gray-matter` to parse frontmatter and does not directly access filesystem, Git, network, or Worker-only APIs. Browser-worker bundling still needs to be proven. |
+| `DraftFilterProcessor` | Browser-safe logic, build/publish behavior | Pure metadata check that can run anywhere, but its behavior is build/publish-oriented because author previews may intentionally render drafts. |
+| `ExcludeProcessor` | Browser-safe core | Pure string transformation over `context.body`; no runtime or external dependencies. |
+| `AstProcessor` | Browser-safe core candidate | Uses `marked.lexer()` and does not directly access runtime-only APIs. Browser-worker bundling still needs to be proven. |
+| `TocProcessor` | Browser-safe core | Pure AST transformation that derives TOC entries from heading tokens. |
+| `HtmlProcessor` | Browser-safe core candidate | Uses `marked` parser/renderer and does not directly access runtime-only APIs. Browser-worker bundling still needs to be proven. |
+| `GitDateProcessor` | Runtime/build-only | Uses Node `child_process` and Git history to enrich `metadata.updated`; not browser-worker safe. |
+| `ImageGeneratorProcessor` | Runtime/build-only | Uses external AI generation, image resizing, R2 upload, manifest reads/writes, and build-time configuration; not browser-worker safe. |
+
+### Build-Time and Template Parity Concerns
+
+Preview parity is not only about matching processors. The build scripts and content creation scripts also affect the identity, placement, and rendered route of a content item.
+
+- Root `package.json` defines `new-content`, `new-session`, `update-date`, and workspace build/deploy scripts. Root `deploy` runs `npm run update-date -- --all` before web deployment, which can change authored `updated` frontmatter before the web build.
+- `web/package.json` defines web build as `npm run build:posts:images && tsc`; this means the default web build path runs build-time content generation with optional image generation before TypeScript compilation.
+- `scripts/new-content.ts` and `scripts/content/generate-content.ts` create files from registered templates, not from the admin preview route. For `post`, the generated slug comes from the title and becomes the filename. For `about`, the filename and slug are fixed as `about.md` and `about`.
+- `scripts/content/template-registry.ts` currently registers `post` and `about` templates with different output directories, required metadata, optional metadata, filename strategies, and layout options.
+- `scripts/templates/post.md` includes `section: "posts"`, `contentType: "post"`, `layout: "article"`, date fields, tags, author, and `draft: true`.
+- `scripts/templates/about.md` writes to the standalone page path with `contentType: "about"`, `layout: "article"`, `slug: "{{SLUG}}"`, and `draft: true`.
+- `scripts/new-session.ts` creates technical-session files outside the generic `new-content` registry. It prefixes the filename with year/month/week, then appends a slugified focus area. That full filename becomes the build-time slug.
+- `web/scripts/build-posts.ts` derives listed content identity from the filesystem: the section slug comes from the content subdirectory, and the item slug comes from the Markdown filename without `.md`.
+- `web/scripts/build-posts.ts` excludes configured standalone page sections from listed section discovery, then separately processes `content/pages/about.md` as a standalone page with stable slug `about` and section `pages`.
+- `web/scripts/build-posts.ts` sorts items within a section by descending `metadata.date` when both compared items have dates, otherwise by title. It sorts sections alphabetically by derived title.
+- The generated `siteContent` shape separates `sections`, `allItems`, and `standalonePages`; runtime routes and caches use that generated structure rather than reparsing Markdown.
+- The browser admin's current "New File" dialog creates a simpler ad hoc draft template from a selected section and slug. It does not use the root `new-content` template registry and does not add `contentType`, `layout`, `section`, `author`, or `updated` frontmatter by default.
+- The admin preview endpoint currently calls the pipeline with placeholder identity values: `filePath`, `slug`, and `section` are all passed as `preview`. That can differ from build output whenever a processor, fallback title, generated URL, schema selection, image key, or warning depends on real file path, slug, or section.
+
+Implication for the spike: a browser-worker preview should either receive the real content identity from the selected or newly generated file path, or it should clearly mark previews that are body-only and cannot prove route, section, standalone-page, image-key, ordering, generated artifact, or publish-readiness parity.
+
+### Preview Parity Rules
+
+Use these rules when evaluating any browser-worker preview proof-of-concept:
+
+- Browser-worker preview is a fast authoring feedback path, not the final publishing authority.
+- Build-time generation remains the production authority because it owns draft filtering, Git date enrichment, optional image generation, generated artifact output, section/listing aggregation, sorting, and standalone-page placement.
+- Server preview remains the authoritative fallback for behavior that cannot safely or practically run in a browser worker.
+- Browser-worker preview should match server preview and build-time output for browser-safe core processing: frontmatter parsing, exclude marker removal, AST generation, TOC generation, and HTML rendering.
+- Browser-worker preview should receive real content identity when available: `filePath`, `slug`, `section`, and whether the item is listed content or a standalone page.
+- If real identity is not available, the preview result must be treated as body-only feedback and must not claim route, section, standalone-page, image-key, ordering, generated artifact, or publish-readiness parity.
+- Runtime/build-only enrichments must be explicit differences, not silent behavior changes. Examples include Git-derived `updated` metadata, draft skipping, image generation, R2 upload, image manifest updates, and generated `posts-data.ts` output.
+- A preview result should expose enough information for the authoring surface to explain its confidence level, including the mode used, identity used, warnings, and any known build-only differences.
+- Any browser-worker implementation should keep server preview available as a fallback while parity confidence is being proven.
+
+### Minimal Proof-of-Concept Plan
+
+The processor inventory shows a practical path worth attempting because the core preview processors are already separated from build-only processors. The proof-of-concept should stay deliberately small and should not replace the existing admin preview route.
+
+The smallest useful POC is:
+
+1. Create a browser-worker entry point that imports only browser-safe candidate processors:
+   - `FrontmatterProcessor`
+   - `ExcludeProcessor`
+   - `AstProcessor`
+   - `TocProcessor`
+   - `HtmlProcessor`
+2. Define a worker request and response shape that accepts:
+   - raw Markdown content;
+   - real identity when available: `filePath`, `slug`, `section`, and listed/standalone kind;
+   - an explicit mode or confidence marker such as `body-only` or `real-identity`.
+3. Return a stable preview result with:
+   - `slug`;
+   - `section`;
+   - `metadata`;
+   - `toc`;
+   - `html`;
+   - `warnings`;
+   - known build-only differences or unavailable enrichments.
+4. Bundle the worker with the existing project tooling or a minimal local bundler command to prove whether `gray-matter`, `marked`, and the shared pipeline modules can run in a browser-worker target.
+5. Run the representative fixtures through the worker result and compare against `web/scripts/compare-preview-parity.ts`.
+
+The POC counts as attempted when there is evidence for one of these outcomes:
+
+- worker bundle succeeds and fixture comparison can run;
+- worker bundle succeeds but fixture comparison exposes meaningful parity gaps;
+- worker bundle fails because a dependency or module shape is not browser-worker compatible;
+- the attempt is stopped because `CR-012` parser or pipeline decisions must happen first.
+
+The POC should avoid:
+
+- Git-derived dates;
+- draft filtering as a publish gate;
+- image generation;
+- R2 upload;
+- image manifest writes;
+- generated `posts-data.ts` writes;
+- replacing the current admin preview UI.
+
+Success for this AC does not require production integration. It only requires a small, recorded attempt with enough evidence to recommend proceed, defer, keep server preview, or drop the browser-worker approach.
+
+### Representative Parity Fixtures
+
+Use these existing content files to validate the current documentation and any proof-of-concept output:
+
+| Fixture | Path | Build-time identity | Why it matters |
+| --- | --- | --- | --- |
+| About page | `content/pages/about.md` | standalone page with slug `about` and section `pages` | Exercises the configured standalone-page path. It is not listed under `/pages`; runtime serves it through the dedicated `/about` route using `standalonePages`. |
+| Technical session | `content/technical-sessions/2025-11-w4-typescript.md` | listed item with section `technical-sessions` and slug `2025-11-w4-typescript` | Exercises filename-derived slugs that include the year/month/week prefix from `new-session`, technical-session schema selection, and exclude-marker removal. |
+| Post | `content/posts/building-intentionally-small.md` | listed item with section `posts` and slug `building-intentionally-small` | Exercises the ordinary listed post path, post card links, section grouping, date sorting, and heading/TOC behavior for article content. |
+
+For these fixtures, compare at least:
+
+- `slug`, `section`, `metadata`, `toc`, and `html` from the server preview path versus the build-time pipeline;
+- behavior when admin preview uses placeholder identity values versus real file-derived identity;
+- whether draft filtering, Git date enrichment, standalone-page handling, exclude markers, and generated artifact placement change the author's understanding of what preview is showing.
+
+Initial comparison result:
+
+- The current admin preview mode differs from build output on `slug`, `section`, and `metadata` because it passes placeholder identity values.
+- The real-identity admin preview mode matches build output on `slug`, `section`, `toc`, `html`, `warnings`, and `skipped` for all three fixtures.
+- The real-identity admin preview mode still differs from build output on `metadata` because build-time `GitDateProcessor` adds or overrides `metadata.updated`.
+- No fixture produced an HTML or TOC difference between admin preview and build-time processing.
+
+### Browser-Worker POC Findings
+
+The minimal browser-worker proof-of-concept was implemented with:
+
+- `web/src/utils/pipeline/browser-preview.ts` for the worker-safe preview request/response contract and core processor pipeline;
+- `web/src/workers/preview-worker.ts` as a worker-shaped entry point;
+- `web/scripts/run-preview-worker-poc.ts` as a local harness that bundles the worker for a browser target and runs the representative fixtures.
+
+The POC command is:
+
+```bash
+npm run preview-worker:poc
+```
+
+Result:
+
+- The browser-target bundle succeeded.
+- Bundle size at the time of the run: `184544` bytes.
+- The bundle required a small `fs.readFileSync` stub because `gray-matter` imports Node `fs` even when processing in-memory Markdown strings.
+- The bundled worker module was imported and executed by the POC harness.
+- The worker-shaped preview result ran for all three representative fixtures.
+- For all fixtures, core preview output matched build output for `skipped`, `slug`, `section`, `metadata` excluding build-only `updated`, `toc`, `html`, and `warnings`.
+- No fixture produced a TOC or HTML mismatch.
+- The worker response shape can carry stable preview data through `identity`, `item`, `warnings`, and `knownBuildOnlyDifferences`.
+- The current browser-safe pipeline does not produce dedicated validation issues yet; validation output should be added intentionally when `CR-010` or `CR-013` define the shared issue shape.
+
+Compatibility notes:
+
+- `marked` worked in the browser-target bundle.
+- Shared pipeline modules worked in the browser-target bundle.
+- `gray-matter` worked only after the POC provided an `fs.readFileSync` stub. A production implementation should decide whether to keep an explicit bundler shim, replace `gray-matter` for browser-worker preview, or defer that decision to `CR-012`.
+- The POC proves browser-target bundling and worker-shaped processing. It does not yet prove production admin UI integration, long-running worker lifecycle behavior in the browser, or cross-browser compatibility.
+
+### Platform Boundary Implications
+
+CR-011 is not only a browser-admin preview spike. It also helps clarify where content processing should run across the future authoring surfaces.
+
+The practical finding is that the pure Markdown preview path can be treated as shared content-core behavior:
+
+```text
+frontmatter -> exclude markers -> AST -> TOC -> HTML -> warnings
+```
+
+That shared core can support browser admin preview, Electron renderer preview, Electron renderer-worker preview, and future tests without each platform inventing a separate preview engine.
+
+The likely platform boundaries are:
+
+| Platform | Best fit |
+| --- | --- |
+| Browser worker or Electron renderer worker | Fast authoring feedback for pure Markdown preview and warning generation without a server round trip. |
+| Electron main process | Filesystem access, Git operations, template generation, `update-date`, running npm scripts, and local build orchestration. |
+| Hono/Cloudflare Worker server preview | Authoritative fallback for deployed admin behavior and runtime-sensitive preview concerns. |
+| Build and CI pipeline | Final production authority for draft filtering, Git date enrichment, optional image generation, generated artifacts, section aggregation, sorting, validation, and deployment readiness. |
+
+This means the Electron content operations POC should not need a separate Markdown preview engine. It should reuse the shared core for renderer-side preview while keeping local filesystem, Git, scripts, and build commands in the Electron main process or another Node-capable boundary.
+
+Open design implication: future extraction should keep pure content processing independent from platform operations. Platform-specific layers can wrap the shared core instead of modifying its contract.
+
+### Follow-Up Candidates
+
+- Pass real content identity into the existing admin server preview so preview no longer uses `preview` placeholders when a file path is known.
+- Decide whether browser-worker preview should keep a bundler-level `fs` shim for `gray-matter` or move frontmatter parsing to a browser-first helper.
+- Add fixture parity checks to the future validation/test workflow once `CR-013` defines content validation checks.
+- Reconcile the browser admin "New File" template with the root `new-content` template registry so generated draft shape is consistent across authoring paths.
+- If browser-worker preview moves forward, add a production implementation request for hidden/internal admin integration with server preview fallback.
+
+## Outcome
+
+The browser-worker preview spike found a practical path forward. The shared core processors can be bundled for a browser target and can produce matching core preview output for the representative about page, technical session, and post fixtures when real file identity is provided.
+
+The recommended direction is to proceed cautiously: keep server preview as the authoritative fallback, pass real identity into preview requests, and decide how to handle browser-worker frontmatter parsing before production integration. Full admin UI replacement is intentionally out of scope for this spike.

--- a/change-requests/index.md
+++ b/change-requests/index.md
@@ -24,7 +24,7 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 | CR-008 | Define publishing workflow rules | Done | High | Publishing | 2026-05-06 | [CR-008-define-publishing-workflow-rules.md](./CR-008-define-publishing-workflow-rules.md) |
 | CR-009 | Add admin metadata editing UI | Proposed | Medium | Web Admin | 2026-05-06 | [CR-009-add-admin-metadata-editing-ui.md](./CR-009-add-admin-metadata-editing-ui.md) |
 | CR-010 | Add admin validation panel and author-facing warnings | Proposed | High | Web Admin | 2026-05-06 | [CR-010-add-admin-validation-panel-and-author-facing-warnings.md](./CR-010-add-admin-validation-panel-and-author-facing-warnings.md) |
-| CR-011 | Spike browser-worker preview pipeline | Proposed | Medium | Content Pipeline | 2026-05-06 | Pending detail |
+| CR-011 | Spike browser-worker preview pipeline | Done | Medium | Content Pipeline | 2026-05-06 | [CR-011-spike-browser-worker-preview-pipeline.md](./CR-011-spike-browser-worker-preview-pipeline.md) |
 | CR-012 | Decide parser roadmap for markdown processing | Proposed | Medium | Content Pipeline | 2026-05-06 | Pending detail |
 | CR-013 | Add CI content validation checks | Proposed | Medium | Quality | 2026-05-06 | Pending detail |
 | CR-014 | Reassess generated content artifact strategy | Proposed | Medium | Architecture | 2026-05-06 | [CR-014-reassess-generated-content-artifact-strategy.md](./CR-014-reassess-generated-content-artifact-strategy.md) |
@@ -39,6 +39,11 @@ Local-first change requests for `mylifeindigital`. Proposed rows may start as li
 | CR-023 | Establish baseline test setup | Proposed | Medium | Quality | 2026-06-16 | [CR-023-establish-baseline-test-setup.md](./CR-023-establish-baseline-test-setup.md) |
 
 ## Backlog Grooming Notes
+
+### 2026-06-20
+
+- Added the `CR-011` detail file to define the browser-worker preview spike, preview parity questions, and its boundaries with `CR-010`, `CR-012`, `CR-013`, and `CR-014`.
+- Completed `CR-011` by adding a browser-worker preview proof-of-concept, documenting parity findings, and recording follow-up candidates.
 
 ### 2026-06-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5291,6 +5291,7 @@
         "@types/marked": "^6.0.0",
         "@types/node": "^25.0.3",
         "dotenv": "^16.0.0",
+        "esbuild": "^0.25.12",
         "sharp": "^0.33.0",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3",
@@ -5411,6 +5412,448 @@
         "node": ">=16"
       }
     },
+    "web/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "web/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "web/node_modules/@types/marked": {
       "version": "6.0.0",
       "deprecated": "This is a stub types definition. marked provides its own type definitions, so you do not need this installed.",
@@ -5441,6 +5884,48 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "web/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "web/node_modules/marked": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "build:utils": "npm run build --workspace=ts-core-utils",
     "build:web": "npm run build --workspace=web",
     "deploy": "npm run update-date -- --all && npm run deploy --workspace=web",
+    "compare:preview-parity": "npm run compare:preview-parity --workspace=web",
+    "preview-worker:poc": "npm run preview-worker:poc --workspace=web",
     "new-content": "tsx scripts/new-content.ts",
     "new-session": "tsx scripts/new-session.ts",
     "test:scripts": "tsx --test scripts/content/*.test.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,8 @@
     "build": "npm run build:posts:images && tsc",
     "build:posts": "tsx scripts/build-posts.ts",
     "build:posts:images": "tsx scripts/build-posts.ts --generate-images",
+    "compare:preview-parity": "tsx scripts/compare-preview-parity.ts",
+    "preview-worker:poc": "tsx scripts/run-preview-worker-poc.ts",
     "generate:images": "tsx scripts/generate-images.ts",
     "deploy": "npm run build:posts && wrangler deploy",
     "start": "wrangler dev"
@@ -30,6 +32,7 @@
     "@types/marked": "^6.0.0",
     "@types/node": "^25.0.3",
     "dotenv": "^16.0.0",
+    "esbuild": "^0.25.12",
     "sharp": "^0.33.0",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",

--- a/web/scripts/compare-preview-parity.ts
+++ b/web/scripts/compare-preview-parity.ts
@@ -1,0 +1,258 @@
+/**
+ * Compare current admin preview output against build-time pipeline output.
+ *
+ * This is a CR-011 spike helper. It intentionally disables image generation so
+ * comparisons stay deterministic and do not require external services.
+ */
+
+import { readFileSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+import { MarkdownProcessingPipeline } from '../src/utils/pipeline/MarkdownProcessingPipeline.js';
+import type { ContentMetadata, TocEntry } from '../src/utils/markdown.js';
+import {
+    FrontmatterProcessor,
+    DraftFilterProcessor,
+    GitDateProcessor,
+    ExcludeProcessor,
+    AstProcessor,
+    TocProcessor,
+    HtmlProcessor,
+} from './processors/index.js';
+
+type PipelineMode = 'admin-current' | 'admin-real-identity' | 'build';
+
+type Fixture = {
+    label: string;
+    relativePath: string;
+    slug: string;
+    section: string;
+    kind: 'standalone' | 'listed';
+};
+
+type ComparableOutput = {
+    skipped: boolean;
+    slug: string | null;
+    section: string | null;
+    metadata: ContentMetadata | null;
+    toc: TocEntry[] | undefined;
+    html: string | null;
+    warnings: string[];
+};
+
+type Comparison = {
+    field: keyof ComparableOutput;
+    equal: boolean;
+};
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '..', '..');
+
+const fixtures: Fixture[] = [
+    {
+        label: 'About page',
+        relativePath: 'content/pages/about.md',
+        slug: 'about',
+        section: 'pages',
+        kind: 'standalone',
+    },
+    {
+        label: 'Technical session',
+        relativePath: 'content/technical-sessions/2025-11-w4-typescript.md',
+        slug: '2025-11-w4-typescript',
+        section: 'technical-sessions',
+        kind: 'listed',
+    },
+    {
+        label: 'Post',
+        relativePath: 'content/posts/building-intentionally-small.md',
+        slug: 'building-intentionally-small',
+        section: 'posts',
+        kind: 'listed',
+    },
+];
+
+function createAdminPreviewPipeline(): MarkdownProcessingPipeline {
+    return new MarkdownProcessingPipeline()
+        .use(new FrontmatterProcessor())
+        .use(new ExcludeProcessor())
+        .use(new AstProcessor())
+        .use(new TocProcessor({ minLevel: 1, maxLevel: 3 }))
+        .use(new HtmlProcessor());
+}
+
+function createBuildPipeline(): MarkdownProcessingPipeline {
+    return new MarkdownProcessingPipeline()
+        .use(new FrontmatterProcessor())
+        .use(new DraftFilterProcessor())
+        .use(new GitDateProcessor())
+        .use(new ExcludeProcessor())
+        .use(new AstProcessor())
+        .use(new TocProcessor({ minLevel: 1, maxLevel: 3 }))
+        .use(new HtmlProcessor());
+}
+
+function getModeIdentity(
+    fixture: Fixture,
+    mode: PipelineMode
+): { filePath: string; slug: string; section: string } {
+    if (mode === 'admin-current') {
+        return {
+            filePath: 'preview',
+            slug: 'preview',
+            section: 'preview',
+        };
+    }
+
+    return {
+        filePath: join(repoRoot, fixture.relativePath),
+        slug: fixture.slug,
+        section: fixture.section,
+    };
+}
+
+async function processFixture(
+    fixture: Fixture,
+    mode: PipelineMode
+): Promise<ComparableOutput> {
+    const filePath = join(repoRoot, fixture.relativePath);
+    const content = readFileSync(filePath, 'utf-8');
+    const identity = getModeIdentity(fixture, mode);
+    const pipeline = mode === 'build'
+        ? createBuildPipeline()
+        : createAdminPreviewPipeline();
+
+    const result = await pipeline.process(
+        content,
+        identity.filePath,
+        identity.slug,
+        identity.section
+    );
+
+    if (result === null) {
+        return {
+            skipped: true,
+            slug: null,
+            section: null,
+            metadata: null,
+            toc: undefined,
+            html: null,
+            warnings: [],
+        };
+    }
+
+    return {
+        skipped: false,
+        slug: result.item.slug,
+        section: result.item.section,
+        metadata: result.item.metadata,
+        toc: result.item.toc,
+        html: result.item.html,
+        warnings: result.warnings,
+    };
+}
+
+function normalize(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(normalize);
+    }
+
+    if (value && typeof value === 'object') {
+        const normalized: Record<string, unknown> = {};
+        for (const key of Object.keys(value).sort()) {
+            normalized[key] = normalize((value as Record<string, unknown>)[key]);
+        }
+        return normalized;
+    }
+
+    return value;
+}
+
+function isEqual(left: unknown, right: unknown): boolean {
+    return JSON.stringify(normalize(left)) === JSON.stringify(normalize(right));
+}
+
+function compareOutputs(
+    left: ComparableOutput,
+    right: ComparableOutput
+): Comparison[] {
+    const fields: Array<keyof ComparableOutput> = [
+        'skipped',
+        'slug',
+        'section',
+        'metadata',
+        'toc',
+        'html',
+        'warnings',
+    ];
+
+    return fields.map(field => ({
+        field,
+        equal: isEqual(left[field], right[field]),
+    }));
+}
+
+function formatComparison(comparisons: Comparison[]): string {
+    return comparisons
+        .map(({ field, equal }) => `${equal ? '✓' : '✗'} ${field}`)
+        .join('\n');
+}
+
+function summarizeOutput(output: ComparableOutput): string {
+    const title = output.metadata?.title ?? '(no title)';
+    const updated = output.metadata?.updated ?? '(none)';
+    const tocCount = output.toc?.length ?? 0;
+    const htmlLength = output.html?.length ?? 0;
+
+    return [
+        `slug=${output.slug ?? '(skipped)'}`,
+        `section=${output.section ?? '(skipped)'}`,
+        `title=${JSON.stringify(title)}`,
+        `updated=${JSON.stringify(updated)}`,
+        `toc=${tocCount}`,
+        `htmlLength=${htmlLength}`,
+        `warnings=${output.warnings.length}`,
+        `skipped=${output.skipped}`,
+    ].join(', ');
+}
+
+async function main(): Promise<void> {
+    console.log('Preview parity comparison');
+    console.log('Image generation is intentionally disabled.\n');
+
+    for (const fixture of fixtures) {
+        console.log(`## ${fixture.label}`);
+        console.log(`${fixture.relativePath} (${fixture.kind})`);
+        console.log(`expected identity: ${fixture.section}/${fixture.slug}`);
+
+        const adminCurrent = await processFixture(fixture, 'admin-current');
+        const adminRealIdentity = await processFixture(fixture, 'admin-real-identity');
+        const build = await processFixture(fixture, 'build');
+
+        console.log('\nadmin-current:');
+        console.log(`  ${summarizeOutput(adminCurrent)}`);
+        console.log('admin-real-identity:');
+        console.log(`  ${summarizeOutput(adminRealIdentity)}`);
+        console.log('build:');
+        console.log(`  ${summarizeOutput(build)}`);
+
+        console.log('\nadmin-current vs build:');
+        console.log(formatComparison(compareOutputs(adminCurrent, build)));
+
+        console.log('\nadmin-real-identity vs build:');
+        console.log(formatComparison(compareOutputs(adminRealIdentity, build)));
+        console.log('');
+    }
+
+    console.log('Notes');
+    console.log('- Differences in slug/section for admin-current are expected because the route passes preview placeholders.');
+    console.log('- Differences in metadata.updated are expected when GitDateProcessor overrides or adds the value at build time.');
+    console.log('- HTML and TOC differences are the highest-signal preview parity issues for body rendering.');
+}
+
+main().catch(error => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Preview parity comparison failed: ${message}`);
+    process.exitCode = 1;
+});

--- a/web/scripts/run-preview-worker-poc.ts
+++ b/web/scripts/run-preview-worker-poc.ts
@@ -1,0 +1,327 @@
+/**
+ * CR-011 browser-worker preview proof-of-concept.
+ *
+ * Bundles the preview worker for a browser target, imports the bundle, and
+ * compares worker-shaped preview output against the build-time pipeline for
+ * representative content fixtures.
+ */
+
+import { mkdirSync, readFileSync, rmSync, statSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { pathToFileURL, fileURLToPath } from 'url';
+import { build, type Plugin } from 'esbuild';
+
+import { MarkdownProcessingPipeline } from '../src/utils/pipeline/MarkdownProcessingPipeline.js';
+import type { ContentItem, ContentMetadata, TocEntry } from '../src/utils/markdown.js';
+import type {
+    BrowserPreviewContentKind,
+    BrowserPreviewRequest,
+    BrowserPreviewResponse,
+} from '../src/utils/pipeline/browser-preview.js';
+import {
+    FrontmatterProcessor,
+    DraftFilterProcessor,
+    GitDateProcessor,
+    ExcludeProcessor,
+    AstProcessor,
+    TocProcessor,
+    HtmlProcessor,
+} from './processors/index.js';
+
+type Fixture = {
+    label: string;
+    relativePath: string;
+    slug: string;
+    section: string;
+    kind: Exclude<BrowserPreviewContentKind, 'unknown'>;
+};
+
+type ComparableOutput = {
+    skipped: boolean;
+    slug: string | null;
+    section: string | null;
+    metadata: ContentMetadata | null;
+    toc: TocEntry[] | undefined;
+    html: string | null;
+    warnings: string[];
+};
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const webRoot = join(scriptDir, '..');
+const repoRoot = join(webRoot, '..');
+const workerEntry = join(webRoot, 'src/workers/preview-worker.ts');
+const outDir = join(tmpdir(), 'mylifeindigital-preview-worker-poc');
+const workerBundlePath = join(outDir, 'preview-worker.bundle.mjs');
+
+const fixtures: Fixture[] = [
+    {
+        label: 'About page',
+        relativePath: 'content/pages/about.md',
+        slug: 'about',
+        section: 'pages',
+        kind: 'standalone',
+    },
+    {
+        label: 'Technical session',
+        relativePath: 'content/technical-sessions/2025-11-w4-typescript.md',
+        slug: '2025-11-w4-typescript',
+        section: 'technical-sessions',
+        kind: 'listed',
+    },
+    {
+        label: 'Post',
+        relativePath: 'content/posts/building-intentionally-small.md',
+        slug: 'building-intentionally-small',
+        section: 'posts',
+        kind: 'listed',
+    },
+];
+
+const fsStubPlugin: Plugin = {
+    name: 'browser-preview-fs-stub',
+    setup(buildContext) {
+        buildContext.onResolve({ filter: /^fs$/ }, () => ({
+            path: 'fs',
+            namespace: 'browser-preview-fs-stub',
+        }));
+
+        buildContext.onLoad(
+            { filter: /^fs$/, namespace: 'browser-preview-fs-stub' },
+            () => ({
+                loader: 'js',
+                contents: `
+                    module.exports = {
+                        readFileSync() {
+                            throw new Error('fs.readFileSync is unavailable in browser preview worker');
+                        }
+                    };
+                `,
+            })
+        );
+    },
+};
+
+function createBuildPipeline(): MarkdownProcessingPipeline {
+    return new MarkdownProcessingPipeline()
+        .use(new FrontmatterProcessor())
+        .use(new DraftFilterProcessor())
+        .use(new GitDateProcessor())
+        .use(new ExcludeProcessor())
+        .use(new AstProcessor())
+        .use(new TocProcessor({ minLevel: 1, maxLevel: 3 }))
+        .use(new HtmlProcessor());
+}
+
+async function processBuildFixture(fixture: Fixture): Promise<ComparableOutput> {
+    const filePath = join(repoRoot, fixture.relativePath);
+    const content = readFileSync(filePath, 'utf-8');
+    const result = await createBuildPipeline().process(
+        content,
+        filePath,
+        fixture.slug,
+        fixture.section
+    );
+
+    if (result === null) {
+        return {
+            skipped: true,
+            slug: null,
+            section: null,
+            metadata: null,
+            toc: undefined,
+            html: null,
+            warnings: [],
+        };
+    }
+
+    return toComparableOutput(result.item, result.warnings);
+}
+
+function toComparableOutput(
+    item: ContentItem | null,
+    warnings: string[]
+): ComparableOutput {
+    if (!item) {
+        return {
+            skipped: true,
+            slug: null,
+            section: null,
+            metadata: null,
+            toc: undefined,
+            html: null,
+            warnings,
+        };
+    }
+
+    return {
+        skipped: false,
+        slug: item.slug,
+        section: item.section,
+        metadata: item.metadata,
+        toc: item.toc,
+        html: item.html,
+        warnings,
+    };
+}
+
+function normalize(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(normalize);
+    }
+
+    if (value && typeof value === 'object') {
+        const normalized: Record<string, unknown> = {};
+        for (const key of Object.keys(value).sort()) {
+            if (key === 'updated') continue;
+            normalized[key] = normalize((value as Record<string, unknown>)[key]);
+        }
+        return normalized;
+    }
+
+    return value;
+}
+
+function isEqual(left: unknown, right: unknown): boolean {
+    return JSON.stringify(normalize(left)) === JSON.stringify(normalize(right));
+}
+
+function compareCorePreviewFields(
+    workerOutput: ComparableOutput,
+    buildOutput: ComparableOutput
+): Array<{ field: keyof ComparableOutput; equal: boolean }> {
+    const fields: Array<keyof ComparableOutput> = [
+        'skipped',
+        'slug',
+        'section',
+        'metadata',
+        'toc',
+        'html',
+        'warnings',
+    ];
+
+    return fields.map(field => ({
+        field,
+        equal: isEqual(workerOutput[field], buildOutput[field]),
+    }));
+}
+
+function printComparisons(comparisons: Array<{ field: string; equal: boolean }>): void {
+    comparisons.forEach(({ field, equal }) => {
+        console.log(`  ${equal ? '✓' : '✗'} ${field}`);
+    });
+}
+
+function summarize(output: ComparableOutput): string {
+    return [
+        `slug=${output.slug ?? '(skipped)'}`,
+        `section=${output.section ?? '(skipped)'}`,
+        `toc=${output.toc?.length ?? 0}`,
+        `htmlLength=${output.html?.length ?? 0}`,
+        `warnings=${output.warnings.length}`,
+        `skipped=${output.skipped}`,
+    ].join(', ');
+}
+
+async function bundleWorker(): Promise<{ bytes: number; warnings: string[] }> {
+    mkdirSync(outDir, { recursive: true });
+
+    const result = await build({
+        entryPoints: [workerEntry],
+        outfile: workerBundlePath,
+        bundle: true,
+        format: 'esm',
+        platform: 'browser',
+        target: 'es2022',
+        write: true,
+        sourcemap: false,
+        logLevel: 'silent',
+        plugins: [fsStubPlugin],
+    });
+
+    return {
+        bytes: statSync(workerBundlePath).size,
+        warnings: result.warnings.map(warning => warning.text),
+    };
+}
+
+async function loadWorkerModule(): Promise<{
+    processPreviewWorkerRequest: (request: BrowserPreviewRequest) => Promise<BrowserPreviewResponse>;
+}> {
+    return await import(pathToFileURL(workerBundlePath).href) as {
+        processPreviewWorkerRequest: (request: BrowserPreviewRequest) => Promise<BrowserPreviewResponse>;
+    };
+}
+
+async function main(): Promise<void> {
+    console.log('Browser-worker preview POC');
+    console.log('Bundling worker target with browser platform...\n');
+
+    let bundleResult: { bytes: number; warnings: string[] };
+    try {
+        bundleResult = await bundleWorker();
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Bundle failed: ${message}`);
+        process.exitCode = 1;
+        return;
+    }
+
+    console.log(`Bundle succeeded: ${workerBundlePath}`);
+    console.log(`Bundle size: ${bundleResult.bytes} bytes`);
+    if (bundleResult.warnings.length > 0) {
+        console.log('Bundle warnings:');
+        bundleResult.warnings.forEach(warning => console.log(`  - ${warning}`));
+    }
+    console.log('');
+
+    const workerModule = await loadWorkerModule();
+    let hasMismatch = false;
+
+    for (const fixture of fixtures) {
+        const filePath = join(repoRoot, fixture.relativePath);
+        const content = readFileSync(filePath, 'utf-8');
+        const request: BrowserPreviewRequest = {
+            content,
+            filePath,
+            slug: fixture.slug,
+            section: fixture.section,
+            kind: fixture.kind,
+            mode: 'real-identity',
+        };
+
+        const workerResponse = await workerModule.processPreviewWorkerRequest(request);
+        const workerOutput = toComparableOutput(workerResponse.item, workerResponse.warnings);
+        const buildOutput = await processBuildFixture(fixture);
+        const comparisons = compareCorePreviewFields(workerOutput, buildOutput);
+        const fixtureHasMismatch = comparisons.some(comparison => !comparison.equal);
+        hasMismatch = hasMismatch || fixtureHasMismatch;
+
+        console.log(`## ${fixture.label}`);
+        console.log(`${fixture.relativePath}`);
+        console.log(`worker: ${summarize(workerOutput)}`);
+        console.log(`build:  ${summarize(buildOutput)}`);
+        console.log('core comparison, ignoring build-only metadata.updated:');
+        printComparisons(comparisons);
+        console.log(`known build-only differences: ${workerResponse.knownBuildOnlyDifferences.length}`);
+        console.log('');
+    }
+
+    console.log('POC findings');
+    console.log('- Browser-target bundle succeeded with a small fs.readFileSync stub for gray-matter.');
+    console.log('- The worker-shaped preview result ran for all representative fixtures.');
+    console.log('- Core preview output matched build output when ignoring build-only metadata.updated.');
+    console.log('- Server preview should remain the fallback while any production worker integration is designed.');
+
+    rmSync(outDir, { recursive: true, force: true });
+
+    if (hasMismatch) {
+        process.exitCode = 1;
+    }
+}
+
+main().catch(error => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Browser-worker preview POC failed: ${message}`);
+    process.exitCode = 1;
+});

--- a/web/src/utils/pipeline/browser-preview.ts
+++ b/web/src/utils/pipeline/browser-preview.ts
@@ -1,0 +1,110 @@
+import { MarkdownProcessingPipeline } from './MarkdownProcessingPipeline.js';
+import type { ContentItem } from '../markdown.js';
+import {
+    FrontmatterProcessor,
+    ExcludeProcessor,
+    AstProcessor,
+    TocProcessor,
+    HtmlProcessor,
+} from './processors/index.js';
+
+export type BrowserPreviewMode = 'body-only' | 'real-identity';
+export type BrowserPreviewContentKind = 'listed' | 'standalone' | 'unknown';
+
+export interface BrowserPreviewRequest {
+    content: string;
+    filePath?: string;
+    slug?: string;
+    section?: string;
+    kind?: BrowserPreviewContentKind;
+    mode?: BrowserPreviewMode;
+}
+
+export interface BrowserPreviewIdentity {
+    filePath: string;
+    slug: string;
+    section: string;
+    kind: BrowserPreviewContentKind;
+    mode: BrowserPreviewMode;
+}
+
+export interface BrowserPreviewResponse {
+    ok: boolean;
+    identity: BrowserPreviewIdentity;
+    item: ContentItem | null;
+    warnings: string[];
+    knownBuildOnlyDifferences: string[];
+    error?: string;
+}
+
+export function createBrowserPreviewPipeline(): MarkdownProcessingPipeline {
+    return new MarkdownProcessingPipeline()
+        .use(new FrontmatterProcessor())
+        .use(new ExcludeProcessor())
+        .use(new AstProcessor())
+        .use(new TocProcessor({ minLevel: 1, maxLevel: 3 }))
+        .use(new HtmlProcessor());
+}
+
+function resolveIdentity(request: BrowserPreviewRequest): BrowserPreviewIdentity {
+    const hasRealIdentity = Boolean(request.filePath && request.slug && request.section);
+    const mode = request.mode ?? (hasRealIdentity ? 'real-identity' : 'body-only');
+
+    return {
+        filePath: request.filePath ?? 'preview',
+        slug: request.slug ?? 'preview',
+        section: request.section ?? 'preview',
+        kind: request.kind ?? 'unknown',
+        mode,
+    };
+}
+
+function getKnownBuildOnlyDifferences(identity: BrowserPreviewIdentity): string[] {
+    const differences = [
+        'Git-derived metadata.updated is not applied in browser preview.',
+        'Draft filtering is not applied as a publish gate in browser preview.',
+        'Image generation, image upload, and image manifest writes are not applied in browser preview.',
+        'Generated posts-data.ts output, section aggregation, sorting, and standalone-page placement are not produced by browser preview.',
+    ];
+
+    if (identity.mode === 'body-only') {
+        differences.push(
+            'Body-only preview cannot prove route, section, standalone-page, image-key, ordering, generated artifact, or publish-readiness parity.'
+        );
+    }
+
+    return differences;
+}
+
+export async function processBrowserPreview(
+    request: BrowserPreviewRequest
+): Promise<BrowserPreviewResponse> {
+    const identity = resolveIdentity(request);
+
+    try {
+        const result = await createBrowserPreviewPipeline().process(
+            request.content,
+            identity.filePath,
+            identity.slug,
+            identity.section
+        );
+
+        return {
+            ok: true,
+            identity,
+            item: result?.item ?? null,
+            warnings: result?.warnings ?? [],
+            knownBuildOnlyDifferences: getKnownBuildOnlyDifferences(identity),
+        };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+            ok: false,
+            identity,
+            item: null,
+            warnings: [],
+            knownBuildOnlyDifferences: getKnownBuildOnlyDifferences(identity),
+            error: message,
+        };
+    }
+}

--- a/web/src/workers/preview-worker.ts
+++ b/web/src/workers/preview-worker.ts
@@ -1,0 +1,27 @@
+import {
+    processBrowserPreview,
+    type BrowserPreviewRequest,
+    type BrowserPreviewResponse,
+} from '../utils/pipeline/browser-preview.js';
+
+export async function processPreviewWorkerRequest(
+    request: BrowserPreviewRequest
+): Promise<BrowserPreviewResponse> {
+    return processBrowserPreview(request);
+}
+
+const workerGlobal = globalThis as typeof globalThis & {
+    addEventListener?: (
+        type: 'message',
+        listener: (event: { data: BrowserPreviewRequest }) => void
+    ) => void;
+    postMessage?: (message: BrowserPreviewResponse) => void;
+};
+
+if (typeof workerGlobal.addEventListener === 'function') {
+    workerGlobal.addEventListener('message', (event) => {
+        void processPreviewWorkerRequest(event.data).then((response) => {
+            workerGlobal.postMessage?.(response);
+        });
+    });
+}


### PR DESCRIPTION
## Summary

Completes `CR-011` by documenting and proving a minimal browser-worker preview path for the shared Markdown processing pipeline.

## Changes

- Added the `CR-011` detail document and marked the request `Done`.
- Documented admin preview vs build-time pipeline differences.
- Classified processors as browser-safe core candidates or runtime/build-only processors.
- Added preview parity rules and representative fixture coverage.
- Added `compare:preview-parity` to compare admin preview and build pipeline output.
- Added a minimal browser-worker preview POC:
  - shared browser preview helper
  - worker-shaped entry point
  - local POC harness with browser-target bundling
- Added `preview-worker:poc` npm scripts at root and web workspace levels.
- Recorded platform-boundary findings for future Electron/content-operations work.

## Findings

- Core preview processors can bundle for a browser target.
- The worker-shaped preview output matched build output for the about page, technical session, and post fixtures.
- `gray-matter` imports Node `fs`, so the POC uses a small `fs.readFileSync` stub for browser-target bundling.
- Build/CI should remain the production authority, while browser-worker preview is a fast authoring feedback path.
- Electron can reuse the shared content-core preview path instead of inventing a separate preview engine.

## Verification

- Ran `npm run preview-worker:poc`.
- Ran `npx tsc --noEmit` from `web/`.
- Ran `git diff --check`.